### PR TITLE
tests do not depend on nose

### DIFF
--- a/kitchen2/tests/test__all__.py
+++ b/kitchen2/tests/test__all__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from nose import tools
+
+import unittest
 
 import os
 import types
@@ -18,7 +19,7 @@ class NoAll(RuntimeError):
 class FailedImport(RuntimeError):
     pass
 
-class Test__all__(object):
+class Test__all__(unittest.TestCase):
     '''Test that every function in __all__ exists and that no public methods
     are missing from __all__
     '''
@@ -100,9 +101,9 @@ class Test__all__(object):
         try:
             try:
                 f = open(modpath, 'rb')
-                tools.ok_('__all__' in f.read(), '%s does not contain __all__' % modpath)
+                self.assertTrue('__all__' in f.read(), '%s does not contain __all__' % modpath)
             except IOError, e:
-                tools.ok_(False, '%s' % e)
+                self.assertTrue(False, '%s' % e)
         finally:
             if f:
                 f.close()
@@ -131,13 +132,13 @@ class Test__all__(object):
             exec 'from %s.%s import *' % (modpath, modname) in interior_names
         except Exception, e:
             # Include the module name in the exception string
-            tools.ok_(False, '__all__ failure in %s: %s: %s' % (
+            self.assertTrue(False, '__all__ failure in %s: %s: %s' % (
                       modname, e.__class__.__name__, e))
         if '__builtins__' in interior_names:
             del interior_names['__builtins__']
         keys = set(interior_names)
         all = set(names[modname].__all__)
-        tools.ok_(keys == all)
+        self.assertTrue(keys == all)
 
     def test_everything_in__all__exists(self):
         '''
@@ -174,7 +175,7 @@ class Test__all__(object):
 
         all = set(mod.__all__)
         public = set(expected_public)
-        tools.ok_(all.issuperset(public), 'These public names are not in %s.__all__: %s'
+        self.assertTrue(all.issuperset(public), 'These public names are not in %s.__all__: %s'
                 % (modname, ', '.join(public.difference(all))))
 
     def test__all__is_complete(self):

--- a/kitchen2/tests/test_collections.py
+++ b/kitchen2/tests/test_collections.py
@@ -1,28 +1,28 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 from kitchen.pycompat24.sets import add_builtin_set
 add_builtin_set()
 
 from kitchen import collections
 
-def test_strict_dict_get_set():
-    '''Test getting and setting items in StrictDict'''
-    d = collections.StrictDict()
-    d[u'a'] = 1
-    d['a'] = 2
-    tools.assert_not_equal(d[u'a'], d['a'])
-    tools.eq_(len(d), 2)
+class TestStrictDictGetSet(unittest.TestCase):
+    def test_strict_dict_get_set(self):
+        '''Test getting and setting items in StrictDict'''
+        d = collections.StrictDict()
+        d[u'a'] = 1
+        d['a'] = 2
+        self.assertNotEqual(d[u'a'], d['a'])
+        self.assertEqual(len(d), 2)
 
-    d[u'\xf1'] = 1
-    d['\xf1'] = 2
-    d[u'\xf1'.encode('utf-8')] = 3
-    tools.eq_(d[u'\xf1'], 1)
-    tools.eq_(d['\xf1'], 2)
-    tools.eq_(d[u'\xf1'.encode('utf-8')], 3)
-    tools.eq_(len(d), 5)
+        d[u'\xf1'] = 1
+        d['\xf1'] = 2
+        d[u'\xf1'.encode('utf-8')] = 3
+        self.assertEqual(d[u'\xf1'], 1)
+        self.assertEqual(d['\xf1'], 2)
+        self.assertEqual(d[u'\xf1'.encode('utf-8')], 3)
+        self.assertEqual(len(d), 5)
 
 class TestStrictDict(unittest.TestCase):
     def setUp(self):
@@ -94,66 +94,66 @@ class TestStrictDict(unittest.TestCase):
 
     def test__compare_list(self):
         '''*sigh* this test support function is so complex we need to test it'''
-        tools.ok_(self._compare_lists(['a', 'b', 'c'], ['c', 'a', 'b']))
-        tools.ok_(not self._compare_lists(['b', 'c'], ['c', 'a', 'b']))
-        tools.ok_(not self._compare_lists([u'a', 'b'], ['a', 'b']))
-        tools.ok_(not self._compare_lists(['a', u'b'], [u'a', 'b']))
-        tools.ok_(self._compare_lists(['a', 'b', 1], ['a', 1, 'b']))
-        tools.ok_(self._compare_lists([u'a', u'b'], [u'a', u'b']))
-        tools.ok_(self._compare_lists([u'a', 'b'], [u'a', 'b']))
-        tools.ok_(not self._compare_lists([u'a', 'b'], [u'a', u'b']))
-        tools.ok_(self._compare_lists([u'a', 'b', 'b', 'c', u'a'], [u'a', u'a', 'b', 'c', 'b']))
-        tools.ok_(not self._compare_lists([u'a', 'b', 'b', 'c', 'a'], [u'a', u'a', 'b', 'c', 'b']))
-        tools.ok_(not self._compare_lists([u'a', 'b', 'b', 'c', u'a'], [u'a', 'b', 'b', 'c', 'b']))
+        self.assertTrue(self._compare_lists(['a', 'b', 'c'], ['c', 'a', 'b']))
+        self.assertTrue(not self._compare_lists(['b', 'c'], ['c', 'a', 'b']))
+        self.assertTrue(not self._compare_lists([u'a', 'b'], ['a', 'b']))
+        self.assertTrue(not self._compare_lists(['a', u'b'], [u'a', 'b']))
+        self.assertTrue(self._compare_lists(['a', 'b', 1], ['a', 1, 'b']))
+        self.assertTrue(self._compare_lists([u'a', u'b'], [u'a', u'b']))
+        self.assertTrue(self._compare_lists([u'a', 'b'], [u'a', 'b']))
+        self.assertTrue(not self._compare_lists([u'a', 'b'], [u'a', u'b']))
+        self.assertTrue(self._compare_lists([u'a', 'b', 'b', 'c', u'a'], [u'a', u'a', 'b', 'c', 'b']))
+        self.assertTrue(not self._compare_lists([u'a', 'b', 'b', 'c', 'a'], [u'a', u'a', 'b', 'c', 'b']))
+        self.assertTrue(not self._compare_lists([u'a', 'b', 'b', 'c', u'a'], [u'a', 'b', 'b', 'c', 'b']))
 
     def test_strict_dict_len(self):
         '''StrictDict len'''
-        tools.eq_(len(self.d), 5)
+        self.assertEqual(len(self.d), 5)
 
     def test_strict_dict_del(self):
         '''StrictDict del'''
-        tools.eq_(len(self.d), 5)
+        self.assertEqual(len(self.d), 5)
         del(self.d[u'\xf1'])
-        tools.assert_raises(KeyError, self.d.__getitem__, u'\xf1')
-        tools.eq_(len(self.d), 4)
+        self.assertRaises(KeyError, self.d.__getitem__, u'\xf1')
+        self.assertEqual(len(self.d), 4)
 
     def test_strict_dict_iter(self):
         '''StrictDict iteration'''
         keys = []
         for k in self.d:
             keys.append(k)
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
         keys = []
         for k in self.d.iterkeys():
             keys.append(k)
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
         keys = [k for k in self.d]
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
         keys = []
         for k in self.d.keys():
             keys.append(k)
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
     def test_strict_dict_contains(self):
         '''StrictDict contains function'''
-        tools.ok_('b' not in self.d)
-        tools.ok_(u'b' not in self.d)
-        tools.ok_('\xf1' in self.d)
-        tools.ok_(u'\xf1' in self.d)
-        tools.ok_('a' in self.d)
-        tools.ok_(u'a' in self.d)
+        self.assertTrue('b' not in self.d)
+        self.assertTrue(u'b' not in self.d)
+        self.assertTrue('\xf1' in self.d)
+        self.assertTrue(u'\xf1' in self.d)
+        self.assertTrue('a' in self.d)
+        self.assertTrue(u'a' in self.d)
 
         del(self.d[u'\xf1'])
-        tools.ok_(u'\xf1' not in self.d)
-        tools.ok_('\xf1' in self.d)
+        self.assertTrue(u'\xf1' not in self.d)
+        self.assertTrue('\xf1' in self.d)
 
         del(self.d['a'])
-        tools.ok_(u'a' in self.d)
-        tools.ok_('a' not in self.d)
+        self.assertTrue(u'a' in self.d)
+        self.assertTrue('a' not in self.d)

--- a/kitchen2/tests/test_converters.py
+++ b/kitchen2/tests/test_converters.py
@@ -2,7 +2,6 @@
 #
 
 import unittest
-from nose import tools
 from nose.plugins.skip import SkipTest
 
 import sys
@@ -49,98 +48,98 @@ class ReprUnicode(object):
 class TestConverters(unittest.TestCase, base_classes.UnicodeTestData):
     def test_to_unicode(self):
         '''Test to_unicode when the user gives good values'''
-        tools.eq_(converters.to_unicode(self.u_japanese, encoding='latin1'), self.u_japanese)
+        self.assertEqual(converters.to_unicode(self.u_japanese, encoding='latin1'), self.u_japanese)
 
-        tools.eq_(converters.to_unicode(self.utf8_spanish), self.u_spanish)
-        tools.eq_(converters.to_unicode(self.utf8_japanese), self.u_japanese)
+        self.assertEqual(converters.to_unicode(self.utf8_spanish), self.u_spanish)
+        self.assertEqual(converters.to_unicode(self.utf8_japanese), self.u_japanese)
 
-        tools.eq_(converters.to_unicode(self.latin1_spanish, encoding='latin1'), self.u_spanish)
-        tools.eq_(converters.to_unicode(self.euc_jp_japanese, encoding='euc_jp'), self.u_japanese)
+        self.assertEqual(converters.to_unicode(self.latin1_spanish, encoding='latin1'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(self.euc_jp_japanese, encoding='euc_jp'), self.u_japanese)
 
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'foo'})
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'foo'})
 
     def test_to_unicode_errors(self):
-        tools.eq_(converters.to_unicode(self.latin1_spanish), self.u_mangled_spanish_latin1_as_utf8)
-        tools.eq_(converters.to_unicode(self.latin1_spanish, errors='ignore'), self.u_spanish_ignore)
-        tools.assert_raises(UnicodeDecodeError, converters.to_unicode,
+        self.assertEqual(converters.to_unicode(self.latin1_spanish), self.u_mangled_spanish_latin1_as_utf8)
+        self.assertEqual(converters.to_unicode(self.latin1_spanish, errors='ignore'), self.u_spanish_ignore)
+        self.assertRaises(UnicodeDecodeError, converters.to_unicode,
                 *[self.latin1_spanish], **{'errors': 'strict'})
 
     def test_to_unicode_nonstring(self):
-        tools.eq_(converters.to_unicode(5), u'5')
-        tools.eq_(converters.to_unicode(5, nonstring='empty'), u'')
-        tools.eq_(converters.to_unicode(5, nonstring='passthru'), 5)
-        tools.eq_(converters.to_unicode(5, nonstring='simplerepr'), u'5')
-        tools.eq_(converters.to_unicode(5, nonstring='repr'), u'5')
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'strict'})
+        self.assertEqual(converters.to_unicode(5), u'5')
+        self.assertEqual(converters.to_unicode(5, nonstring='empty'), u'')
+        self.assertEqual(converters.to_unicode(5, nonstring='passthru'), 5)
+        self.assertEqual(converters.to_unicode(5, nonstring='simplerepr'), u'5')
+        self.assertEqual(converters.to_unicode(5, nonstring='repr'), u'5')
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'strict'})
 
         obj_repr = converters.to_unicode(object, nonstring='simplerepr')
-        tools.eq_(obj_repr, u"<type 'object'>")
-        tools.assert_true(isinstance(obj_repr, unicode))
+        self.assertEqual(obj_repr, u"<type 'object'>")
+        self.assertTrue(isinstance(obj_repr, unicode))
 
     def test_to_unicode_nonstring_with_objects_that_have__unicode__and__str__(self):
         '''Test that to_unicode handles objects that have  __unicode__ and  __str__ methods'''
         if sys.version_info < (3, 0):
             # None of these apply on python3 because python3 does not use __unicode__
             # and it enforces __str__ returning str
-            tools.eq_(converters.to_unicode(UnicodeNoStr(), nonstring='simplerepr'), self.u_spanish)
-            tools.eq_(converters.to_unicode(StrNoUnicode(), nonstring='simplerepr'), self.u_spanish)
-            tools.eq_(converters.to_unicode(UnicodeReturnsStr(), nonstring='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(UnicodeNoStr(), nonstring='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(StrNoUnicode(), nonstring='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(UnicodeReturnsStr(), nonstring='simplerepr'), self.u_spanish)
 
-        tools.eq_(converters.to_unicode(StrReturnsUnicode(), nonstring='simplerepr'), self.u_spanish)
-        tools.eq_(converters.to_unicode(UnicodeStrCrossed(), nonstring='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(StrReturnsUnicode(), nonstring='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(UnicodeStrCrossed(), nonstring='simplerepr'), self.u_spanish)
 
     def test_to_bytes(self):
         '''Test to_bytes when the user gives good values'''
-        tools.eq_(converters.to_bytes(self.utf8_japanese, encoding='latin1'), self.utf8_japanese)
+        self.assertEqual(converters.to_bytes(self.utf8_japanese, encoding='latin1'), self.utf8_japanese)
 
-        tools.eq_(converters.to_bytes(self.u_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_bytes(self.u_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_bytes(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(self.u_japanese), self.utf8_japanese)
 
-        tools.eq_(converters.to_bytes(self.u_spanish, encoding='latin1'), self.latin1_spanish)
-        tools.eq_(converters.to_bytes(self.u_japanese, encoding='euc_jp'), self.euc_jp_japanese)
+        self.assertEqual(converters.to_bytes(self.u_spanish, encoding='latin1'), self.latin1_spanish)
+        self.assertEqual(converters.to_bytes(self.u_japanese, encoding='euc_jp'), self.euc_jp_japanese)
 
     def test_to_bytes_errors(self):
-        tools.eq_(converters.to_bytes(self.u_mixed, encoding='latin1'),
+        self.assertEqual(converters.to_bytes(self.u_mixed, encoding='latin1'),
                 self.latin1_mixed_replace)
-        tools.eq_(converters.to_bytes(self.u_mixed, encoding='latin',
+        self.assertEqual(converters.to_bytes(self.u_mixed, encoding='latin',
             errors='ignore'), self.latin1_mixed_ignore)
-        tools.assert_raises(UnicodeEncodeError, converters.to_bytes,
+        self.assertRaises(UnicodeEncodeError, converters.to_bytes,
             *[self.u_mixed], **{'errors': 'strict', 'encoding': 'latin1'})
 
     def _check_repr_bytes(self, repr_string, obj_name):
-        tools.assert_true(isinstance(repr_string, str))
+        self.assertTrue(isinstance(repr_string, str))
         match = self.repr_re.match(repr_string)
-        tools.assert_not_equal(match, None)
-        tools.eq_(match.groups()[0], obj_name)
+        self.assertNotEqual(match, None)
+        self.assertEqual(match.groups()[0], obj_name)
 
     def test_to_bytes_nonstring(self):
-        tools.eq_(converters.to_bytes(5), '5')
-        tools.eq_(converters.to_bytes(5, nonstring='empty'), '')
-        tools.eq_(converters.to_bytes(5, nonstring='passthru'), 5)
-        tools.eq_(converters.to_bytes(5, nonstring='simplerepr'), '5')
-        tools.eq_(converters.to_bytes(5, nonstring='repr'), '5')
+        self.assertEqual(converters.to_bytes(5), '5')
+        self.assertEqual(converters.to_bytes(5, nonstring='empty'), '')
+        self.assertEqual(converters.to_bytes(5, nonstring='passthru'), 5)
+        self.assertEqual(converters.to_bytes(5, nonstring='simplerepr'), '5')
+        self.assertEqual(converters.to_bytes(5, nonstring='repr'), '5')
 
         # Raise a TypeError if the msg is nonstring and we're set to strict
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'strict'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'strict'})
         # Raise a TypeError if given an invalid nonstring arg
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'INVALID'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'INVALID'})
 
         obj_repr = converters.to_bytes(object, nonstring='simplerepr')
-        tools.eq_(obj_repr, "<type 'object'>")
-        tools.assert_true(isinstance(obj_repr, str))
+        self.assertEqual(obj_repr, "<type 'object'>")
+        self.assertTrue(isinstance(obj_repr, str))
 
     def test_to_bytes_nonstring_with_objects_that_have__unicode__and__str__(self):
         if sys.version_info < (3, 0):
             # This object's _str__ returns a utf8 encoded object
-            tools.eq_(converters.to_bytes(StrNoUnicode(), nonstring='simplerepr'), self.utf8_spanish)
+            self.assertEqual(converters.to_bytes(StrNoUnicode(), nonstring='simplerepr'), self.utf8_spanish)
         # No __str__ method so this returns repr
         string = converters.to_bytes(UnicodeNoStr(), nonstring='simplerepr')
         self._check_repr_bytes(string, 'UnicodeNoStr')
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(), nonstring='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(), nonstring='simplerepr'), self.utf8_spanish)
         # Unless we explicitly ask for something different
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(),
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(),
             nonstring='simplerepr', encoding='latin1'), self.latin1_spanish)
 
         # This object has no __str__ so it returns repr
@@ -148,79 +147,79 @@ class TestConverters(unittest.TestCase, base_classes.UnicodeTestData):
         self._check_repr_bytes(string, 'UnicodeReturnsStr')
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(UnicodeStrCrossed(), nonstring='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(UnicodeStrCrossed(), nonstring='simplerepr'), self.utf8_spanish)
 
         # This object's __repr__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(ReprUnicode(), nonstring='simplerepr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), nonstring='simplerepr'),
                 u'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
-        tools.eq_(converters.to_bytes(ReprUnicode(), nonstring='repr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), nonstring='repr'),
                 u'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
 
     def test_unicode_to_xml(self):
-        tools.eq_(converters.unicode_to_xml(None), '')
-        tools.assert_raises(XmlEncodeError, converters.unicode_to_xml, *['byte string'])
-        tools.assert_raises(ValueError, converters.unicode_to_xml, *[u'string'], **{'control_chars': 'foo'})
-        tools.assert_raises(XmlEncodeError, converters.unicode_to_xml,
+        self.assertEqual(converters.unicode_to_xml(None), '')
+        self.assertRaises(XmlEncodeError, converters.unicode_to_xml, *['byte string'])
+        self.assertRaises(ValueError, converters.unicode_to_xml, *[u'string'], **{'control_chars': 'foo'})
+        self.assertRaises(XmlEncodeError, converters.unicode_to_xml,
                 *[u'string\u0002'], **{'control_chars': 'strict'})
-        tools.eq_(converters.unicode_to_xml(self.u_entity), self.utf8_entity_escape)
-        tools.eq_(converters.unicode_to_xml(self.u_entity, attrib=True), self.utf8_attrib_escape)
-        tools.eq_(converters.unicode_to_xml(self.u_entity, encoding='ascii'), self.ascii_entity_escape)
-        tools.eq_(converters.unicode_to_xml(self.u_entity, encoding='ascii', attrib=True), self.ascii_attrib_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity, attrib=True), self.utf8_attrib_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity, encoding='ascii'), self.ascii_entity_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity, encoding='ascii', attrib=True), self.ascii_attrib_escape)
 
     def test_xml_to_unicode(self):
-        tools.eq_(converters.xml_to_unicode(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity)
-        tools.eq_(converters.xml_to_unicode(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity)
-        tools.eq_(converters.xml_to_unicode(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity)
-        tools.eq_(converters.xml_to_unicode(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity)
 
     def test_xml_to_byte_string(self):
-        tools.eq_(converters.xml_to_byte_string(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
-        tools.eq_(converters.xml_to_byte_string(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
 
-        tools.eq_(converters.xml_to_byte_string(self.utf8_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_attrib_escape,
             output_encoding='euc_jp', errors='replace'),
             self.u_entity.encode('euc_jp', 'replace'))
-        tools.eq_(converters.xml_to_byte_string(self.utf8_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_attrib_escape,
             output_encoding='latin1', errors='replace'),
             self.u_entity.encode('latin1', 'replace'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_attrib_escape,
             output_encoding='euc_jp', errors='replace'),
             self.u_entity.encode('euc_jp', 'replace'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_attrib_escape,
             output_encoding='latin1', errors='replace'),
             self.u_entity.encode('latin1', 'replace'))
 
     def test_byte_string_to_xml(self):
-        tools.assert_raises(XmlEncodeError, converters.byte_string_to_xml, *[u'test'])
-        tools.eq_(converters.byte_string_to_xml(self.utf8_entity), self.utf8_entity_escape)
-        tools.eq_(converters.byte_string_to_xml(self.utf8_entity, attrib=True), self.utf8_attrib_escape)
+        self.assertRaises(XmlEncodeError, converters.byte_string_to_xml, *[u'test'])
+        self.assertEqual(converters.byte_string_to_xml(self.utf8_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.byte_string_to_xml(self.utf8_entity, attrib=True), self.utf8_attrib_escape)
 
     def test_bytes_to_xml(self):
-        tools.eq_(converters.bytes_to_xml(self.b_byte_chars), self.b_byte_encoded)
+        self.assertEqual(converters.bytes_to_xml(self.b_byte_chars), self.b_byte_encoded)
 
     def test_xml_to_bytes(self):
-        tools.eq_(converters.xml_to_bytes(self.b_byte_encoded), self.b_byte_chars)
+        self.assertEqual(converters.xml_to_bytes(self.b_byte_encoded), self.b_byte_chars)
 
     def test_guess_encoding_to_xml(self):
-        tools.eq_(converters.guess_encoding_to_xml(self.u_entity), self.utf8_entity_escape)
-        tools.eq_(converters.guess_encoding_to_xml(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(converters.guess_encoding_to_xml(self.latin1_spanish), self.utf8_spanish)
-        tools.eq_(converters.guess_encoding_to_xml(self.utf8_japanese), self.utf8_japanese)
+        self.assertEqual(converters.guess_encoding_to_xml(self.u_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.guess_encoding_to_xml(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.guess_encoding_to_xml(self.latin1_spanish), self.utf8_spanish)
+        self.assertEqual(converters.guess_encoding_to_xml(self.utf8_japanese), self.utf8_japanese)
 
     def test_guess_encoding_to_xml_euc_japanese(self):
         if chardet:
-            tools.eq_(converters.guess_encoding_to_xml(self.euc_jp_japanese),
+            self.assertEqual(converters.guess_encoding_to_xml(self.euc_jp_japanese),
                     self.utf8_japanese)
         else:
-            raise SkipTest('chardet not installed, euc_japanese won\'t be detected')
+            self.skipTest('chardet not installed, euc_japanese won\'t be detected')
 
     def test_guess_encoding_to_xml_euc_japanese_mangled(self):
         if chardet:
-            raise SkipTest('chardet installed, euc_japanese won\'t be mangled')
+            self.skipTest('chardet installed, euc_japanese won\'t be mangled')
         else:
-            tools.eq_(converters.guess_encoding_to_xml(self.euc_jp_japanese),
+            self.assertEqual(converters.guess_encoding_to_xml(self.euc_jp_japanese),
                     self.utf8_mangled_euc_jp_as_latin1)
 
 class TestGetWriter(unittest.TestCase, base_classes.UnicodeTestData):
@@ -233,27 +232,27 @@ class TestGetWriter(unittest.TestCase, base_classes.UnicodeTestData):
         io.write(self.u_japanese + u'\n')
         io.seek(0)
         result = io.read().strip()
-        tools.eq_(result, self.utf8_japanese)
+        self.assertEqual(result, self.utf8_japanese)
 
         io.seek(0)
         io.truncate(0)
         io.write(self.euc_jp_japanese + '\n')
         io.seek(0)
         result = io.read().strip()
-        tools.eq_(result, self.euc_jp_japanese)
+        self.assertEqual(result, self.euc_jp_japanese)
 
         io.seek(0)
         io.truncate(0)
         io.write(self.utf8_japanese + '\n')
         io.seek(0)
         result = io.read().strip()
-        tools.eq_(result, self.utf8_japanese)
+        self.assertEqual(result, self.utf8_japanese)
 
     def test_error_handlers(self):
         '''Test setting alternate error handlers'''
         writer = converters.getwriter('latin1')
         io = writer(self.io, errors='strict')
-        tools.assert_raises(UnicodeEncodeError, io.write, self.u_japanese)
+        self.assertRaises(UnicodeEncodeError, io.write, self.u_japanese)
 
 
 class TestExceptionConverters(unittest.TestCase, base_classes.UnicodeTestData):
@@ -272,61 +271,61 @@ class TestExceptionConverters(unittest.TestCase, base_classes.UnicodeTestData):
                 pass
 
     def test_exception_to_unicode_with_unicode(self):
-        tools.eq_(converters.exception_to_unicode(self.exceptions['u_jpn']), self.u_japanese)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['u_spanish']), self.u_spanish)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['u_jpn']), self.u_japanese)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['u_spanish']), self.u_spanish)
 
     def test_exception_to_unicode_with_bytes(self):
-        tools.eq_(converters.exception_to_unicode(self.exceptions['utf8_jpn']), self.u_japanese)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['utf8_spanish']), self.u_spanish)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['utf8_jpn']), self.u_japanese)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['utf8_spanish']), self.u_spanish)
         # Mangled latin1/utf8 conversion but no tracebacks
-        tools.eq_(converters.exception_to_unicode(self.exceptions['latin1_spanish']), self.u_mangled_spanish_latin1_as_utf8)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['latin1_spanish']), self.u_mangled_spanish_latin1_as_utf8)
         # Mangled euc_jp/utf8 conversion but no tracebacks
-        tools.eq_(converters.exception_to_unicode(self.exceptions['euc_jpn']), self.u_mangled_euc_jp_as_utf8)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['euc_jpn']), self.u_mangled_euc_jp_as_utf8)
 
     def test_exception_to_unicode_custom(self):
         # If given custom functions, then we should not mangle
         c = [lambda e: converters.to_unicode(e.args[0], encoding='euc_jp'),
                 lambda e: converters.to_unicode(e, encoding='euc_jp')]
-        tools.eq_(converters.exception_to_unicode(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['euc_jpn'],
             converters=c), self.u_japanese)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['euc_jpn'],
             converters=c), self.u_japanese)
 
         c = [lambda e: converters.to_unicode(e.args[0], encoding='latin1'),
                 lambda e: converters.to_unicode(e, encoding='latin1')]
-        tools.eq_(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
             converters=c),  self.u_spanish)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
             converters=c),  self.u_spanish)
 
     def test_exception_to_bytes_with_unicode(self):
-        tools.eq_(converters.exception_to_bytes(self.exceptions['u_jpn']), self.utf8_japanese)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['u_spanish']), self.utf8_spanish)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['u_jpn']), self.utf8_japanese)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['u_spanish']), self.utf8_spanish)
 
     def test_exception_to_bytes_with_bytes(self):
-        tools.eq_(converters.exception_to_bytes(self.exceptions['utf8_jpn']), self.utf8_japanese)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['utf8_spanish']), self.utf8_spanish)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['latin1_spanish']), self.latin1_spanish)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['euc_jpn']), self.euc_jp_japanese)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['utf8_jpn']), self.utf8_japanese)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['utf8_spanish']), self.utf8_spanish)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['latin1_spanish']), self.latin1_spanish)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['euc_jpn']), self.euc_jp_japanese)
 
     def test_exception_to_bytes_custom(self):
         # If given custom functions, then we should not mangle
         c = [lambda e: converters.to_bytes(e.args[0], encoding='euc_jp'),
                 lambda e: converters.to_bytes(e, encoding='euc_jp')]
-        tools.eq_(converters.exception_to_bytes(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['euc_jpn'],
             converters=c), self.euc_jp_japanese)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['euc_jpn'],
             converters=c), self.euc_jp_japanese)
 
         c = [lambda e: converters.to_bytes(e.args[0], encoding='latin1'),
                 lambda e: converters.to_bytes(e, encoding='latin1')]
-        tools.eq_(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
             converters=c),  self.latin1_spanish)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
             converters=c),  self.latin1_spanish)
 
 
@@ -338,63 +337,63 @@ class TestDeprecatedConverters(TestConverters):
         warnings.simplefilter('default', DeprecationWarning)
 
     def test_to_xml(self):
-        tools.eq_(converters.to_xml(self.u_entity), self.utf8_entity_escape)
-        tools.eq_(converters.to_xml(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_xml(self.latin1_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_xml(self.utf8_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_xml(self.u_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.to_xml(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_xml(self.latin1_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_xml(self.utf8_japanese), self.utf8_japanese)
 
     def test_to_utf8(self):
-        tools.eq_(converters.to_utf8(self.u_japanese), self.utf8_japanese)
-        tools.eq_(converters.to_utf8(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_utf8(self.u_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_utf8(self.utf8_spanish), self.utf8_spanish)
 
     def test_to_str(self):
-        tools.eq_(converters.to_str(self.u_japanese), self.utf8_japanese)
-        tools.eq_(converters.to_str(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_str(object), "<type 'object'>")
+        self.assertEqual(converters.to_str(self.u_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_str(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_str(object), "<type 'object'>")
 
     def test_non_string(self):
         '''Test deprecated non_string parameter'''
         # unicode
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'non_string': 'foo'})
-        tools.eq_(converters.to_unicode(5, non_string='empty'), u'')
-        tools.eq_(converters.to_unicode(5, non_string='passthru'), 5)
-        tools.eq_(converters.to_unicode(5, non_string='simplerepr'), u'5')
-        tools.eq_(converters.to_unicode(5, non_string='repr'), u'5')
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'non_string': 'strict'})
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'non_string': 'foo'})
+        self.assertEqual(converters.to_unicode(5, non_string='empty'), u'')
+        self.assertEqual(converters.to_unicode(5, non_string='passthru'), 5)
+        self.assertEqual(converters.to_unicode(5, non_string='simplerepr'), u'5')
+        self.assertEqual(converters.to_unicode(5, non_string='repr'), u'5')
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'non_string': 'strict'})
 
-        tools.eq_(converters.to_unicode(UnicodeNoStr(), non_string='simplerepr'), self.u_spanish)
-        tools.eq_(converters.to_unicode(StrNoUnicode(), non_string='simplerepr'), self.u_spanish)
-        tools.eq_(converters.to_unicode(StrReturnsUnicode(), non_string='simplerepr'), self.u_spanish)
-        tools.eq_(converters.to_unicode(UnicodeReturnsStr(), non_string='simplerepr'), self.u_spanish)
-        tools.eq_(converters.to_unicode(UnicodeStrCrossed(), non_string='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(UnicodeNoStr(), non_string='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(StrNoUnicode(), non_string='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(StrReturnsUnicode(), non_string='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(UnicodeReturnsStr(), non_string='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(UnicodeStrCrossed(), non_string='simplerepr'), self.u_spanish)
 
         obj_repr = converters.to_unicode(object, non_string='simplerepr')
-        tools.eq_(obj_repr, u"<type 'object'>")
-        tools.assert_true(isinstance(obj_repr, unicode))
+        self.assertEqual(obj_repr, u"<type 'object'>")
+        self.assertTrue(isinstance(obj_repr, unicode))
 
         # Bytes
-        tools.eq_(converters.to_bytes(5), '5')
-        tools.eq_(converters.to_bytes(5, non_string='empty'), '')
-        tools.eq_(converters.to_bytes(5, non_string='passthru'), 5)
-        tools.eq_(converters.to_bytes(5, non_string='simplerepr'), '5')
-        tools.eq_(converters.to_bytes(5, non_string='repr'), '5')
+        self.assertEqual(converters.to_bytes(5), '5')
+        self.assertEqual(converters.to_bytes(5, non_string='empty'), '')
+        self.assertEqual(converters.to_bytes(5, non_string='passthru'), 5)
+        self.assertEqual(converters.to_bytes(5, non_string='simplerepr'), '5')
+        self.assertEqual(converters.to_bytes(5, non_string='repr'), '5')
 
         # Raise a TypeError if the msg is non_string and we're set to strict
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'non_string': 'strict'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'non_string': 'strict'})
         # Raise a TypeError if given an invalid non_string arg
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'non_string': 'INVALID'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'non_string': 'INVALID'})
 
         # No __str__ method so this returns repr
         string = converters.to_bytes(UnicodeNoStr(), non_string='simplerepr')
         self._check_repr_bytes(string, 'UnicodeNoStr')
 
         # This object's _str__ returns a utf8 encoded object
-        tools.eq_(converters.to_bytes(StrNoUnicode(), non_string='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(StrNoUnicode(), non_string='simplerepr'), self.utf8_spanish)
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(), non_string='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(), non_string='simplerepr'), self.utf8_spanish)
         # Unless we explicitly ask for something different
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(),
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(),
             non_string='simplerepr', encoding='latin1'), self.latin1_spanish)
 
         # This object has no __str__ so it returns repr
@@ -402,14 +401,14 @@ class TestDeprecatedConverters(TestConverters):
         self._check_repr_bytes(string, 'UnicodeReturnsStr')
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(UnicodeStrCrossed(), non_string='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(UnicodeStrCrossed(), non_string='simplerepr'), self.utf8_spanish)
 
         # This object's __repr__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(ReprUnicode(), non_string='simplerepr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), non_string='simplerepr'),
                 u'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
-        tools.eq_(converters.to_bytes(ReprUnicode(), non_string='repr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), non_string='repr'),
                 u'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
 
         obj_repr = converters.to_bytes(object, non_string='simplerepr')
-        tools.eq_(obj_repr, "<type 'object'>")
-        tools.assert_true(isinstance(obj_repr, str))
+        self.assertEqual(obj_repr, "<type 'object'>")
+        self.assertTrue(isinstance(obj_repr, str))

--- a/kitchen2/tests/test_converters.py
+++ b/kitchen2/tests/test_converters.py
@@ -2,7 +2,6 @@
 #
 
 import unittest
-from nose.plugins.skip import SkipTest
 
 import sys
 import StringIO

--- a/kitchen2/tests/test_deprecation.py
+++ b/kitchen2/tests/test_deprecation.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 import sys
 import warnings
@@ -21,27 +20,27 @@ class TestDeprecated(unittest.TestCase):
 
     def test_deprecated_functions(self):
         '''Test that all deprecated functions raise DeprecationWarning'''
-        tools.assert_raises(DeprecationWarning, converters.to_utf8, u'café')
-        tools.assert_raises(DeprecationWarning, converters.to_str, 5)
-        tools.assert_raises(DeprecationWarning, converters.to_xml, 'test')
+        self.assertRaises(DeprecationWarning, converters.to_utf8, u'café')
+        self.assertRaises(DeprecationWarning, converters.to_str, 5)
+        self.assertRaises(DeprecationWarning, converters.to_xml, 'test')
 
-        tools.assert_raises(DeprecationWarning, utf8.utf8_valid, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_width, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_width_chop, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_width_fill, 'test', 'asd')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_text_wrap, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_text_fill, 'test')
-        tools.assert_raises(DeprecationWarning, utf8._utf8_width_le, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_valid, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_width, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_width_chop, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_width_fill, 'test', 'asd')
+        self.assertRaises(DeprecationWarning, utf8.utf8_text_wrap, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_text_fill, 'test')
+        self.assertRaises(DeprecationWarning, utf8._utf8_width_le, 'test')
 
     def test_deprecated_parameters(self):
-        tools.assert_raises(DeprecationWarning, converters.to_unicode, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_unicode, *[5],
                 **{'non_string': 'simplerepr'})
-        tools.assert_raises(DeprecationWarning, converters.to_unicode, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_unicode, *[5],
                 **{'nonstring': 'simplerepr', 'non_string': 'simplerepr'})
 
-        tools.assert_raises(DeprecationWarning, converters.to_bytes, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_bytes, *[5],
                 **{'non_string': 'simplerepr'})
-        tools.assert_raises(DeprecationWarning, converters.to_bytes, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_bytes, *[5],
                 **{'nonstring': 'simplerepr', 'non_string': 'simplerepr'})
 
 
@@ -57,7 +56,7 @@ class TestPendingDeprecationParameters(unittest.TestCase):
 
     def test_parameters(self):
         # test that we warn when using the python2_api parameters
-        tools.assert_raises(PendingDeprecationWarning,
+        self.assertRaises(PendingDeprecationWarning,
                 i18n.get_translation_object, 'test', **{'python2_api': True})
-        tools.assert_raises(PendingDeprecationWarning,
+        self.assertRaises(PendingDeprecationWarning,
                 i18n.DummyTranslations, **{'python2_api': True})

--- a/kitchen2/tests/test_i18n.py
+++ b/kitchen2/tests/test_i18n.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 import os
 import types
@@ -31,17 +30,17 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
         '''
         _, N_ = i18n.easy_gettext_setup('foo', localedirs=
                 ['%s/data/locale/' % os.path.dirname(__file__)])
-        tools.assert_true(isinstance(_, types.MethodType))
-        tools.assert_true(isinstance(N_, types.MethodType))
-        tools.eq_(_.__name__, '_ugettext')
-        tools.eq_(N_.__name__, '_ungettext')
+        self.assertTrue(isinstance(_, types.MethodType))
+        self.assertTrue(isinstance(N_, types.MethodType))
+        self.assertEqual(_.__name__, '_ugettext')
+        self.assertEqual(N_.__name__, '_ungettext')
 
-        tools.eq_(_(self.utf8_spanish), self.u_spanish)
-        tools.eq_(_(self.u_spanish), self.u_spanish)
-        tools.eq_(N_(self.utf8_limao, self.utf8_limoes, 1), self.u_limao)
-        tools.eq_(N_(self.utf8_limao, self.utf8_limoes, 2), self.u_limoes)
-        tools.eq_(N_(self.u_limao, self.u_limoes, 1), self.u_limao)
-        tools.eq_(N_(self.u_limao, self.u_limoes, 2), self.u_limoes)
+        self.assertEqual(_(self.utf8_spanish), self.u_spanish)
+        self.assertEqual(_(self.u_spanish), self.u_spanish)
+        self.assertEqual(N_(self.utf8_limao, self.utf8_limoes, 1), self.u_limao)
+        self.assertEqual(N_(self.utf8_limao, self.utf8_limoes, 2), self.u_limoes)
+        self.assertEqual(N_(self.u_limao, self.u_limoes, 1), self.u_limao)
+        self.assertEqual(N_(self.u_limao, self.u_limoes, 2), self.u_limoes)
 
     def test_easy_gettext_setup_non_unicode(self):
         '''Test that the easy_gettext_setup function works
@@ -49,35 +48,35 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
         b_, bN_ = i18n.easy_gettext_setup('foo', localedirs=
                 ['%s/data/locale/' % os.path.dirname(__file__)],
                 use_unicode=False)
-        tools.assert_true(isinstance(b_, types.MethodType))
-        tools.assert_true(isinstance(bN_, types.MethodType))
-        tools.eq_(b_.__name__, '_lgettext')
-        tools.eq_(bN_.__name__, '_lngettext')
+        self.assertTrue(isinstance(b_, types.MethodType))
+        self.assertTrue(isinstance(bN_, types.MethodType))
+        self.assertEqual(b_.__name__, '_lgettext')
+        self.assertEqual(bN_.__name__, '_lngettext')
 
-        tools.eq_(b_(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(b_(self.u_spanish), self.utf8_spanish)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 1), self.utf8_limao)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 2), self.utf8_limoes)
+        self.assertEqual(b_(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(b_(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 1), self.utf8_limao)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 2), self.utf8_limoes)
 
     def test_get_translation_object(self):
         '''Test that the get_translation_object function works
         '''
         translations = i18n.get_translation_object('foo', ['%s/data/locale/' % os.path.dirname(__file__)])
-        tools.eq_(translations.__class__, i18n.DummyTranslations)
-        tools.assert_raises(IOError, i18n.get_translation_object, 'foo', ['%s/data/locale/' % os.path.dirname(__file__)], fallback=False)
+        self.assertEqual(translations.__class__, i18n.DummyTranslations)
+        self.assertRaises(IOError, i18n.get_translation_object, 'foo', ['%s/data/locale/' % os.path.dirname(__file__)], fallback=False)
 
         translations = i18n.get_translation_object('test', ['%s/data/locale/' % os.path.dirname(__file__)])
-        tools.eq_(translations.__class__, i18n.NewGNUTranslations)
+        self.assertEqual(translations.__class__, i18n.NewGNUTranslations)
 
     def test_get_translation_object_create_fallback(self):
         '''Test get_translation_object creates fallbacks for additional catalogs'''
         translations = i18n.get_translation_object('test',
                 ['%s/data/locale' % os.path.dirname(__file__),
                     '%s/data/locale-old' % os.path.dirname(__file__)])
-        tools.eq_(translations.__class__, i18n.NewGNUTranslations)
-        tools.eq_(translations._fallback.__class__, i18n.NewGNUTranslations)
+        self.assertEqual(translations.__class__, i18n.NewGNUTranslations)
+        self.assertEqual(translations._fallback.__class__, i18n.NewGNUTranslations)
 
     def test_get_translation_object_copy(self):
         '''Test get_translation_object shallow copies the message catalog'''
@@ -93,16 +92,16 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
         # Test that portions of the translation objects are the same and other
         # portions are different (which is a space optimization so that the
         # translation data isn't in memory multiple times)
-        tools.assert_not_equal(id(translations._fallback), id(translations2._fallback))
-        tools.assert_not_equal(id(translations.output_charset()), id(translations2.output_charset()))
-        tools.assert_not_equal(id(translations.input_charset), id(translations2.input_charset))
-        tools.assert_not_equal(id(translations.input_charset), id(translations2.input_charset))
-        tools.eq_(id(translations._catalog), id(translations2._catalog))
+        self.assertNotEqual(id(translations._fallback), id(translations2._fallback))
+        self.assertNotEqual(id(translations.output_charset()), id(translations2.output_charset()))
+        self.assertNotEqual(id(translations.input_charset), id(translations2.input_charset))
+        self.assertNotEqual(id(translations.input_charset), id(translations2.input_charset))
+        self.assertEqual(id(translations._catalog), id(translations2._catalog))
 
     def test_get_translation_object_optional_params(self):
         '''Smoketest leaving out optional parameters'''
         translations = i18n.get_translation_object('test')
-        tools.assert_true(translations.__class__ in (i18n.NewGNUTranslations, i18n.DummyTranslations))
+        self.assertTrue(translations.__class__ in (i18n.NewGNUTranslations, i18n.DummyTranslations))
 
     def test_get_translation_object_python2_api_default(self):
         '''Smoketest that python2_api default value yields the python2 functions'''
@@ -111,12 +110,12 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
                 ['%s/data/locale' % os.path.dirname(__file__),
                     '%s/data/locale-old' % os.path.dirname(__file__)], codeset='utf-8')
         translations.input_charset = 'utf-8'
-        tools.eq_(translations.gettext.__name__, '_gettext')
-        tools.eq_(translations.lgettext.__name__, '_lgettext')
-        tools.eq_(translations.ugettext.__name__, '_ugettext')
-        tools.eq_(translations.ngettext.__name__, '_ngettext')
-        tools.eq_(translations.lngettext.__name__, '_lngettext')
-        tools.eq_(translations.ungettext.__name__, '_ungettext')
+        self.assertEqual(translations.gettext.__name__, '_gettext')
+        self.assertEqual(translations.lgettext.__name__, '_lgettext')
+        self.assertEqual(translations.ugettext.__name__, '_ugettext')
+        self.assertEqual(translations.ngettext.__name__, '_ngettext')
+        self.assertEqual(translations.lngettext.__name__, '_lngettext')
+        self.assertEqual(translations.ungettext.__name__, '_ungettext')
 
     def test_get_translation_object_python2_api_true(self):
         '''Smoketest that setting python2_api true yields the python2 functions'''
@@ -126,12 +125,12 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
                     '%s/data/locale-old' % os.path.dirname(__file__)], codeset='utf-8',
                 python2_api=True)
         translations.input_charset = 'utf-8'
-        tools.eq_(translations.gettext.__name__, '_gettext')
-        tools.eq_(translations.lgettext.__name__, '_lgettext')
-        tools.eq_(translations.ugettext.__name__, '_ugettext')
-        tools.eq_(translations.ngettext.__name__, '_ngettext')
-        tools.eq_(translations.lngettext.__name__, '_lngettext')
-        tools.eq_(translations.ungettext.__name__, '_ungettext')
+        self.assertEqual(translations.gettext.__name__, '_gettext')
+        self.assertEqual(translations.lgettext.__name__, '_lgettext')
+        self.assertEqual(translations.ugettext.__name__, '_ugettext')
+        self.assertEqual(translations.ngettext.__name__, '_ngettext')
+        self.assertEqual(translations.lngettext.__name__, '_lngettext')
+        self.assertEqual(translations.ungettext.__name__, '_ungettext')
 
     def test_get_translation_object_python2_api_false(self):
         '''Smoketest that setting python2_api false yields the python3 functions'''
@@ -141,23 +140,23 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
                     '%s/data/locale-old' % os.path.dirname(__file__)], codeset='utf-8',
                 python2_api=False)
         translations.input_charset = 'utf-8'
-        tools.eq_(translations.gettext.__name__, '_ugettext')
-        tools.eq_(translations.lgettext.__name__, '_lgettext')
-        tools.eq_(translations.ngettext.__name__, '_ungettext')
-        tools.eq_(translations.lngettext.__name__, '_lngettext')
+        self.assertEqual(translations.gettext.__name__, '_ugettext')
+        self.assertEqual(translations.lgettext.__name__, '_lgettext')
+        self.assertEqual(translations.ngettext.__name__, '_ungettext')
+        self.assertEqual(translations.lngettext.__name__, '_lngettext')
 
-        tools.assert_raises(AttributeError, translations.ugettext, 'message')
-        tools.assert_raises(AttributeError, translations.ungettext, 'message1', 'message2')
+        self.assertRaises(AttributeError, translations.ugettext, 'message')
+        self.assertRaises(AttributeError, translations.ungettext, 'message1', 'message2')
 
     def test_dummy_translation(self):
         '''Test that we can create a DummyTranslation object
         '''
-        tools.assert_true(isinstance(i18n.DummyTranslations(), i18n.DummyTranslations))
+        self.assertTrue(isinstance(i18n.DummyTranslations(), i18n.DummyTranslations))
 
 # Note: Using nose's generator tests for this so we can't subclass
 # unittest.TestCase
-class TestDummyTranslations(base_classes.UnicodeTestData):
-    def __init__(self):
+class TestDummyTranslations(unittest.TestCase, base_classes.UnicodeTestData):
+    def setUp(self):
         self.test_data = {'bytes': (( # First set is with default charset (utf8)
                 (self.u_ascii, self.b_ascii),
                 (self.u_spanish, self.utf8_spanish),
@@ -214,14 +213,12 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
                 (self.utf8_japanese, self.u_mangled_japanese_utf8_as_ascii), # String mangled but no exception
                 ),
             )
-    }
-
-    def setUp(self):
+        }
         self.translations = i18n.DummyTranslations()
 
     def check_gettext(self, message, value, charset=None):
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.gettext(message), value,
+        self.assertEqual(self.translations.gettext(message), value,
                 msg='gettext(%s): trans: %s != val: %s (charset=%s)'
                 % (repr(message), repr(self.translations.gettext(message)),
                     repr(value), charset))
@@ -230,7 +227,7 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
             locale='en_US.UTF-8'):
         os.environ['LC_ALL'] = locale
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.lgettext(message), value,
+        self.assertEqual(self.translations.lgettext(message), value,
                 msg='lgettext(%s): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lgettext(message)),
                     repr(value), charset, locale))
@@ -240,34 +237,34 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
     def check_ugettext(self, message, value, charset='utf-8'):
         '''ugettext method with default values'''
         self.translations.input_charset = charset
-        tools.eq_(self.translations.ugettext(message), value,
+        self.assertEqual(self.translations.ugettext(message), value,
                 msg='ugettext(%s): trans: %s != val: %s (charset=%s)'
                 % (repr(message), repr(self.translations.ugettext(message)),
                     repr(value), charset))
 
     def check_ngettext(self, message, value, charset=None):
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.ngettext(message, 'blank', 1), value)
-        tools.eq_(self.translations.ngettext('blank', message, 2), value)
-        tools.assert_not_equal(self.translations.ngettext(message, 'blank', 2), value)
-        tools.assert_not_equal(self.translations.ngettext('blank', message, 1), value)
+        self.assertEqual(self.translations.ngettext(message, 'blank', 1), value)
+        self.assertEqual(self.translations.ngettext('blank', message, 2), value)
+        self.assertNotEqual(self.translations.ngettext(message, 'blank', 2), value)
+        self.assertNotEqual(self.translations.ngettext('blank', message, 1), value)
 
     def check_lngettext(self, message, value, charset=None, locale='en_US.UTF-8'):
         os.environ['LC_ALL'] = locale
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.lngettext(message, 'blank', 1), value,
+        self.assertEqual(self.translations.lngettext(message, 'blank', 1), value,
                 msg='lngettext(%s, "blank", 1): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext(message,
                     'blank', 1)), repr(value), charset, locale))
-        tools.eq_(self.translations.lngettext('blank', message, 2), value,
+        self.assertEqual(self.translations.lngettext('blank', message, 2), value,
                 msg='lngettext("blank", %s, 2): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext('blank',
                     message, 2)), repr(value), charset, locale))
-        tools.assert_not_equal(self.translations.lngettext(message, 'blank', 2), value,
+        self.assertNotEqual(self.translations.lngettext(message, 'blank', 2), value,
                 msg='lngettext(%s, "blank", 2): trans: %s, val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext(message,
                     'blank', 2)), repr(value), charset, locale))
-        tools.assert_not_equal(self.translations.lngettext('blank', message, 1), value,
+        self.assertNotEqual(self.translations.lngettext('blank', message, 1), value,
                 msg='lngettext("blank", %s, 1): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext('blank',
                     message, 1)), repr(value), charset, locale))
@@ -276,10 +273,10 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
     # tearDown each time check_* is run.
     def check_ungettext(self, message, value, charset='utf-8'):
         self.translations.input_charset = charset
-        tools.eq_(self.translations.ungettext(message, 'blank', 1), value)
-        tools.eq_(self.translations.ungettext('blank', message, 2), value)
-        tools.assert_not_equal(self.translations.ungettext(message, 'blank', 2), value)
-        tools.assert_not_equal(self.translations.ungettext('blank', message, 1), value)
+        self.assertEqual(self.translations.ungettext(message, 'blank', 1), value)
+        self.assertEqual(self.translations.ungettext('blank', message, 2), value)
+        self.assertNotEqual(self.translations.ungettext(message, 'blank', 2), value)
+        self.assertNotEqual(self.translations.ungettext('blank', message, 1), value)
 
     def test_gettext(self):
         '''gettext method with default values'''
@@ -370,12 +367,12 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
             yield self.check_ungettext, message, value, 'ascii'
 
     def test_nonbasestring(self):
-        tools.eq_(self.translations.gettext(dict(hi='there')), self.b_empty_string)
-        tools.eq_(self.translations.ngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
-        tools.eq_(self.translations.lgettext(dict(hi='there')), self.b_empty_string)
-        tools.eq_(self.translations.lngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
-        tools.eq_(self.translations.ugettext(dict(hi='there')), self.u_empty_string)
-        tools.eq_(self.translations.ungettext(dict(hi='there'), dict(hi='two'), 1), self.u_empty_string)
+        self.assertEqual(self.translations.gettext(dict(hi='there')), self.b_empty_string)
+        self.assertEqual(self.translations.ngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
+        self.assertEqual(self.translations.lgettext(dict(hi='there')), self.b_empty_string)
+        self.assertEqual(self.translations.lngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
+        self.assertEqual(self.translations.ugettext(dict(hi='there')), self.u_empty_string)
+        self.assertEqual(self.translations.ungettext(dict(hi='there'), dict(hi='two'), 1), self.u_empty_string)
 
 
 class TestI18N_Latin1(unittest.TestCase, base_classes.UnicodeTestData):
@@ -401,12 +398,12 @@ class TestI18N_Latin1(unittest.TestCase, base_classes.UnicodeTestData):
                 ['%s/data/locale/' % os.path.dirname(__file__)],
                 use_unicode=False)
 
-        tools.eq_(b_(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(b_(self.u_spanish), self.latin1_spanish)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 1), self.latin1_limao)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 2), self.latin1_limoes)
+        self.assertEqual(b_(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(b_(self.u_spanish), self.latin1_spanish)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 1), self.latin1_limao)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 2), self.latin1_limoes)
 
 
 class TestNewGNUTranslationsNoMatch(TestDummyTranslations):
@@ -448,104 +445,104 @@ class TestNewGNURealTranslations_UTF8(unittest.TestCase, base_classes.UnicodeTes
 
     def test_gettext(self):
         _ = self.translations.gettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_ngettext(self):
         _ = self.translations.ngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
 
     def test_ugettext(self):
         _ = self.translations.ugettext
-        tools.eq_(_(self.utf8_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.u_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.u_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.u_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.u_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.u_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.u_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.u_not_in_catalog)
 
     def test_ungettext(self):
         _ = self.translations.ungettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
 
 
 class TestNewGNURealTranslations_Latin1(TestNewGNURealTranslations_UTF8):
@@ -568,43 +565,43 @@ class TestNewGNURealTranslations_Latin1(TestNewGNURealTranslations_UTF8):
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
         # Neither of the following two tests encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
         #
         # This is not translated to latin1_yes_in_fallback because this test
         # is without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.latin1_ja_kuratomi)
         # This is not translated to latin1_yes_in_fallback because this test
         # is without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.latin1_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.latin1_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
 
         # This unfortunately does not encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
 
 
 class TestFallbackNewGNUTranslationsNoMatch(TestDummyTranslations):
@@ -650,90 +647,90 @@ class TestFallbackNewGNURealTranslations_UTF8(unittest.TestCase, base_classes.Un
 
     def test_gettext(self):
         _ = self.translations.gettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_ngettext(self):
         _ = self.translations.ngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
     def test_ugettext(self):
         _ = self.translations.ugettext
-        tools.eq_(_(self.utf8_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.u_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.u_yes_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.u_yes_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.u_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.u_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.u_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.u_not_in_catalog)
 
     def test_ungettext(self):
         _ = self.translations.ungettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
 
 
 class TestFallbackNewGNURealTranslations_Latin1(TestFallbackNewGNURealTranslations_UTF8):
@@ -758,38 +755,38 @@ class TestFallbackNewGNURealTranslations_Latin1(TestFallbackNewGNURealTranslatio
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.latin1_yes_in_fallback)
+        self.assertEqual(_(self.utf8_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.latin1_yes_in_fallback)
         # This unfortunately does not encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.latin1_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.latin1_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.latin1_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
 
         # This unfortunately does not encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
 
 
 class TestFallback(unittest.TestCase, base_classes.UnicodeTestData):
@@ -820,21 +817,21 @@ class TestFallback(unittest.TestCase, base_classes.UnicodeTestData):
 
     def test_invalid_fallback_no_raise(self):
         '''Test when we have an invalid fallback that it does not raise.'''
-        tools.eq_(self.gtranslations.gettext(self.u_spanish), self.utf8_spanish)
-        tools.eq_(self.gtranslations.ugettext(self.u_spanish), self.u_spanish)
-        tools.eq_(self.gtranslations.lgettext(self.u_spanish), self.latin1_spanish)
+        self.assertEqual(self.gtranslations.gettext(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(self.gtranslations.ugettext(self.u_spanish), self.u_spanish)
+        self.assertEqual(self.gtranslations.lgettext(self.u_spanish), self.latin1_spanish)
 
-        tools.eq_(self.gtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
-        tools.eq_(self.gtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
-        tools.eq_(self.gtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
+        self.assertEqual(self.gtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
+        self.assertEqual(self.gtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
+        self.assertEqual(self.gtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
 
-        tools.eq_(self.dtranslations.gettext(self.u_spanish), self.utf8_spanish)
-        tools.eq_(self.dtranslations.ugettext(self.u_spanish), self.u_spanish)
-        tools.eq_(self.dtranslations.lgettext(self.u_spanish), self.latin1_spanish)
+        self.assertEqual(self.dtranslations.gettext(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(self.dtranslations.ugettext(self.u_spanish), self.u_spanish)
+        self.assertEqual(self.dtranslations.lgettext(self.u_spanish), self.latin1_spanish)
 
-        tools.eq_(self.dtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
-        tools.eq_(self.dtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
-        tools.eq_(self.dtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
+        self.assertEqual(self.dtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
+        self.assertEqual(self.dtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
+        self.assertEqual(self.dtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
 
 
 class TestDefaultLocaleDir(unittest.TestCase, base_classes.UnicodeTestData):
@@ -863,16 +860,16 @@ class TestDefaultLocaleDir(unittest.TestCase, base_classes.UnicodeTestData):
 
     def test_gettext(self):
         _ = self.translations.gettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
         # Returns msgid because the string is in a fallback catalog which we
         # haven't setup
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
         # Returns msgid because the string is in a fallback catalog which we
         # haven't setup
-        tools.eq_(_(self.u_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_in_fallback)

--- a/kitchen2/tests/test_iterutils.py
+++ b/kitchen2/tests/test_iterutils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 from kitchen import iterutils
 
@@ -31,32 +30,32 @@ class TestIterutils(unittest.TestCase):
 
     def test_isiterable(self):
         for item in self.iterable_data:
-            tools.ok_(iterutils.isiterable(item) == True)
+            self.assertTrue(iterutils.isiterable(item) == True)
 
         for item in self.non_iterable_data:
-            tools.ok_(iterutils.isiterable(item) == False)
+            self.assertTrue(iterutils.isiterable(item) == False)
 
         # strings
-        tools.ok_(iterutils.isiterable('a', include_string=True) == True)
-        tools.ok_(iterutils.isiterable('a', include_string=False) == False)
-        tools.ok_(iterutils.isiterable('a') == False)
-        tools.ok_(iterutils.isiterable(u'a', include_string=True) == True)
-        tools.ok_(iterutils.isiterable(u'a', include_string=False) == False)
-        tools.ok_(iterutils.isiterable(u'a') == False)
+        self.assertTrue(iterutils.isiterable('a', include_string=True) == True)
+        self.assertTrue(iterutils.isiterable('a', include_string=False) == False)
+        self.assertTrue(iterutils.isiterable('a') == False)
+        self.assertTrue(iterutils.isiterable(u'a', include_string=True) == True)
+        self.assertTrue(iterutils.isiterable(u'a', include_string=False) == False)
+        self.assertTrue(iterutils.isiterable(u'a') == False)
 
     def test_iterate(self):
         iterutils.iterate(None)
         for item in self.non_iterable_data:
-            tools.ok_(list(iterutils.iterate(item)) == [item])
+            self.assertTrue(list(iterutils.iterate(item)) == [item])
 
         for item in self.iterable_data[:-1]:
-            tools.ok_(list(iterutils.iterate(item)) == list(item))
+            self.assertTrue(list(iterutils.iterate(item)) == list(item))
 
         # iter() is exhausted after use so we have to test separately
-        tools.ok_(list(iterutils.iterate(iter([1, 2, 3]))) == [1, 2, 3])
+        self.assertTrue(list(iterutils.iterate(iter([1, 2, 3]))) == [1, 2, 3])
 
         # strings
-        tools.ok_(list(iterutils.iterate('abc')) == ['abc'])
-        tools.ok_(list(iterutils.iterate('abc', include_string=True)) == ['a', 'b', 'c'])
-        tools.ok_(list(iterutils.iterate(u'abc')) == [u'abc'])
-        tools.ok_(list(iterutils.iterate(u'abc', include_string=True)) == [u'a', u'b', u'c'])
+        self.assertTrue(list(iterutils.iterate('abc')) == ['abc'])
+        self.assertTrue(list(iterutils.iterate('abc', include_string=True)) == ['a', 'b', 'c'])
+        self.assertTrue(list(iterutils.iterate(u'abc')) == [u'abc'])
+        self.assertTrue(list(iterutils.iterate(u'abc', include_string=True)) == [u'a', u'b', u'c'])

--- a/kitchen2/tests/test_pycompat.py
+++ b/kitchen2/tests/test_pycompat.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 class TestUsableModules(unittest.TestCase):
     def test_subprocess(self):
@@ -10,11 +9,11 @@ class TestUsableModules(unittest.TestCase):
         try:
             from kitchen.pycompat24.subprocess import Popen
         except ImportError:
-            tools.ok_(False, 'Unable to import pycompat24.subprocess as a module')
+            self.assertTrue(False, 'Unable to import pycompat24.subprocess as a module')
         try:
             from kitchen.pycompat27.subprocess import Popen
         except ImportError:
-            tools.ok_(False, 'Unable to import pycompat27.subprocess as a module')
+            self.assertTrue(False, 'Unable to import pycompat27.subprocess as a module')
 
     def test_base64(self):
         '''Test that importing base64 as a module works
@@ -22,4 +21,4 @@ class TestUsableModules(unittest.TestCase):
         try:
             from kitchen.pycompat24.base64 import b64encode
         except ImportError:
-            tools.ok_(False, 'Unable to import pycompat24.base64 as a module')
+            self.assertTrue(False, 'Unable to import pycompat24.base64 as a module')

--- a/kitchen2/tests/test_pycompat24.py
+++ b/kitchen2/tests/test_pycompat24.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 from nose.plugins.skip import SkipTest
 
 import __builtin__
@@ -34,8 +33,8 @@ class TestSetsNoOverwrite(unittest.TestCase):
         '''Test that importing sets when there's already a set and frozenset defined does not overwrite
         '''
         sets.add_builtin_set()
-        tools.ok_(__builtin__.set == self.set_val)
-        tools.ok_(__builtin__.frozenset == self.frozenset_val)
+        self.assertTrue(__builtin__.set == self.set_val)
+        self.assertTrue(__builtin__.frozenset == self.frozenset_val)
 
 class TestDefineSets(unittest.TestCase):
     def setUp(self):
@@ -66,11 +65,11 @@ class TestDefineSets(unittest.TestCase):
         import sets as py_sets
         sets.add_builtin_set()
         if self.set_val:
-            tools.ok_(__builtin__.set == self.set_val)
-            tools.ok_(__builtin__.frozenset == self.frozenset_val)
+            self.assertTrue(__builtin__.set == self.set_val)
+            self.assertTrue(__builtin__.frozenset == self.frozenset_val)
         else:
-            tools.ok_(__builtin__.set == py_sets.Set)
-            tools.ok_(__builtin__.frozenset == py_sets.ImmutableSet)
+            self.assertTrue(__builtin__.set == py_sets.Set)
+            self.assertTrue(__builtin__.frozenset == py_sets.ImmutableSet)
 
 class TestSubprocess(unittest.TestCase):
     pass
@@ -81,29 +80,29 @@ class TestBase64(unittest.TestCase):
     b_byte_encoded_urlsafe = 'ACABIAIgAyAEIAUgBiAHIAggCSAKIAsgDCANIA4gDyAQIBEgEiATIBQgFSAWIBcgGCAZIBogGyAcIB0gHiAfICAgISAiICMgJCAlICYgJyAoICkgKiArICwgLSAuIC8gMCAxIDIgMyA0IDUgNiA3IDggOSA6IDsgPCA9ID4gPyBAIEEgQiBDIEQgRSBGIEcgSCBJIEogSyBMIE0gTiBPIFAgUSBSIFMgVCBVIFYgVyBYIFkgWiBbIFwgXSBeIF8gYCBhIGIgYyBkIGUgZiBnIGggaSBqIGsgbCBtIG4gbyBwIHEgciBzIHQgdSB2IHcgeCB5IHogeyB8IH0gfiB_IIAggSCCIIMghCCFIIYghyCIIIkgiiCLIIwgjSCOII8gkCCRIJIgkyCUIJUgliCXIJggmSCaIJsgnCCdIJ4gnyCgIKEgoiCjIKQgpSCmIKcgqCCpIKogqyCsIK0griCvILAgsSCyILMgtCC1ILYgtyC4ILkguiC7ILwgvSC-IL8gwCDBIMIgwyDEIMUgxiDHIMggySDKIMsgzCDNIM4gzyDQINEg0iDTINQg1SDWINcg2CDZINog2yDcIN0g3iDfIOAg4SDiIOMg5CDlIOYg5yDoIOkg6iDrIOwg7SDuIO8g8CDxIPIg8yD0IPUg9iD3IPgg-SD6IPsg_CD9IP4g_w=='
 
     def test_base64_encode(self):
-        tools.ok_(base64.b64encode(self.b_byte_chars) == self.b_byte_encoded)
-        tools.ok_(base64.b64encode(self.b_byte_chars, altchars='-_') == self.b_byte_encoded_urlsafe)
-        tools.ok_(base64.standard_b64encode(self.b_byte_chars) == self.b_byte_encoded)
-        tools.ok_(base64.urlsafe_b64encode(self.b_byte_chars) == self.b_byte_encoded_urlsafe)
+        self.assertTrue(base64.b64encode(self.b_byte_chars) == self.b_byte_encoded)
+        self.assertTrue(base64.b64encode(self.b_byte_chars, altchars='-_') == self.b_byte_encoded_urlsafe)
+        self.assertTrue(base64.standard_b64encode(self.b_byte_chars) == self.b_byte_encoded)
+        self.assertTrue(base64.urlsafe_b64encode(self.b_byte_chars) == self.b_byte_encoded_urlsafe)
 
-        tools.ok_(base64.b64encode(self.b_byte_chars) == self.b_byte_encoded)
-        tools.ok_(base64.b64encode(self.b_byte_chars, altchars='-_') == self.b_byte_encoded_urlsafe)
-        tools.ok_(base64.standard_b64encode(self.b_byte_chars) == self.b_byte_encoded)
-        tools.ok_(base64.urlsafe_b64encode(self.b_byte_chars) == self.b_byte_encoded_urlsafe)
+        self.assertTrue(base64.b64encode(self.b_byte_chars) == self.b_byte_encoded)
+        self.assertTrue(base64.b64encode(self.b_byte_chars, altchars='-_') == self.b_byte_encoded_urlsafe)
+        self.assertTrue(base64.standard_b64encode(self.b_byte_chars) == self.b_byte_encoded)
+        self.assertTrue(base64.urlsafe_b64encode(self.b_byte_chars) == self.b_byte_encoded_urlsafe)
 
     def test_base64_decode(self):
-        tools.ok_(base64.b64decode(self.b_byte_encoded) == self.b_byte_chars)
-        tools.ok_(base64.b64decode(self.b_byte_encoded_urlsafe, altchars='-_') == self.b_byte_chars)
-        tools.ok_(base64.standard_b64decode(self.b_byte_encoded) == self.b_byte_chars)
-        tools.ok_(base64.urlsafe_b64decode(self.b_byte_encoded_urlsafe) == self.b_byte_chars)
+        self.assertTrue(base64.b64decode(self.b_byte_encoded) == self.b_byte_chars)
+        self.assertTrue(base64.b64decode(self.b_byte_encoded_urlsafe, altchars='-_') == self.b_byte_chars)
+        self.assertTrue(base64.standard_b64decode(self.b_byte_encoded) == self.b_byte_chars)
+        self.assertTrue(base64.urlsafe_b64decode(self.b_byte_encoded_urlsafe) == self.b_byte_chars)
 
-        tools.ok_(base64.b64decode(self.b_byte_encoded) == self.b_byte_chars)
-        tools.ok_(base64.b64decode(self.b_byte_encoded_urlsafe, altchars='-_') == self.b_byte_chars)
-        tools.ok_(base64.standard_b64decode(self.b_byte_encoded) == self.b_byte_chars)
-        tools.ok_(base64.urlsafe_b64decode(self.b_byte_encoded_urlsafe) == self.b_byte_chars)
+        self.assertTrue(base64.b64decode(self.b_byte_encoded) == self.b_byte_chars)
+        self.assertTrue(base64.b64decode(self.b_byte_encoded_urlsafe, altchars='-_') == self.b_byte_chars)
+        self.assertTrue(base64.standard_b64decode(self.b_byte_encoded) == self.b_byte_chars)
+        self.assertTrue(base64.urlsafe_b64decode(self.b_byte_encoded_urlsafe) == self.b_byte_chars)
 
     def test_base64_stdlib_compat(self):
         if not hasattr(py_b64, 'b64encode'):
-            raise SkipTest('Python-2.3 doesn\'t have b64encode to compare against')
-        tools.ok_(base64.b64encode(self.b_byte_chars) == py_b64.b64encode(self.b_byte_chars))
-        tools.ok_(base64.b64decode(self.b_byte_chars) == py_b64.b64decode(self.b_byte_chars))
+            self.skipTest('Python-2.3 doesn\'t have b64encode to compare against')
+        self.assertTrue(base64.b64encode(self.b_byte_chars) == py_b64.b64encode(self.b_byte_chars))
+        self.assertTrue(base64.b64decode(self.b_byte_chars) == py_b64.b64decode(self.b_byte_chars))

--- a/kitchen2/tests/test_pycompat24.py
+++ b/kitchen2/tests/test_pycompat24.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose.plugins.skip import SkipTest
 
 import __builtin__
 import base64 as py_b64

--- a/kitchen2/tests/test_subprocess.py
+++ b/kitchen2/tests/test_subprocess.py
@@ -1,5 +1,4 @@
 import unittest
-from nose.plugins.skip import SkipTest
 from kitchen.pycompat27.subprocess import _subprocess as subprocess
 import sys
 import StringIO

--- a/kitchen2/tests/test_subprocess.py
+++ b/kitchen2/tests/test_subprocess.py
@@ -481,7 +481,7 @@ class ProcessTestCase(BaseTestCase):
     # Test for the fd leak reported in http://bugs.python.org/issue2791.
     def test_communicate_pipe_fd_leak(self):
         if not os.path.isdir('/proc/%d/fd' % os.getpid()):
-            raise SkipTest('Linux specific')
+            self.skipTest('Linux specific')
         fd_directory = '/proc/%d/fd' % os.getpid()
         num_fds_before_popen = len(os.listdir(fd_directory))
         p = subprocess.Popen([sys.executable, "-c", "print()"],
@@ -602,7 +602,7 @@ class ProcessTestCase(BaseTestCase):
 
     def test_no_leaking(self):
         if not test_support:
-            raise SkipTest("No test_support module available.")
+            self.skipTest("No test_support module available.")
 
         # Make sure we leak no resources
         if not mswindows:
@@ -623,7 +623,7 @@ class ProcessTestCase(BaseTestCase):
                 # python-2.3  unittest doesn't have skipTest.  Reimplement with nose
                 #self.skipTest("failed to reach the file descriptor limit "
                 #    "(tried %d)" % max_handles)
-                raise SkipTest("failed to reach the file descriptor limit "
+                self.skipTest("failed to reach the file descriptor limit "
                     "(tried %d)" % max_handles)
 
             # Close a couple of them (should be enough for a subprocess)
@@ -805,7 +805,7 @@ class _SuppressCoreFiles(object):
     #                     "Requires signal.SIGALRM")
     def test_communicate_eintr(self):
         if not hasattr(signal, 'SIGALRM'):
-            raise SkipTest('Requires signal.SIGALRM')
+            self.skipTest('Requires signal.SIGALRM')
         # Issue #12493: communicate() should handle EINTR
         def handler(signum, frame):
             pass
@@ -832,7 +832,7 @@ class _SuppressCoreFiles(object):
 class POSIXProcessTestCase(BaseTestCase):
     def setUp(self):
         if mswindows:
-            raise SkipTest('POSIX specific tests')
+            self.skipTest('POSIX specific tests')
 
     def test_exceptions(self):
         # caught & re-raised exceptions
@@ -965,7 +965,7 @@ class POSIXProcessTestCase(BaseTestCase):
 
             # skipTest unavailable on python<2.7 reimplement with nose
             #self.skipTest("bash or ksh required for this test")
-            raise SkipTest("bash or ksh required for this test")
+            self.skipTest("bash or ksh required for this test")
         sh = '/bin/sh'
         if os.path.isfile(sh) and not os.path.islink(sh):
             # Test will fail if /bin/sh is a symlink to csh.
@@ -1132,7 +1132,7 @@ class POSIXProcessTestCase(BaseTestCase):
     def test_wait_when_sigchild_ignored(self):
         # NOTE: sigchild_ignore.py may not be an effective test on all OSes.
         if not test_support:
-            raise SkipTest("No test_support module available.")
+            self.skipTest("No test_support module available.")
         sigchild_ignore = test_support.findfile(os.path.join("subprocessdata",
             "sigchild_ignore.py"))
         p = subprocess.Popen([sys.executable, sigchild_ignore],
@@ -1252,7 +1252,7 @@ class POSIXProcessTestCase(BaseTestCase):
 class Win32ProcessTestCase(BaseTestCase):
     def setUp(self):
         if not mswindows:
-            raise SkipTest('Windows specific tests')
+            self.skipTest('Windows specific tests')
 
     def test_startupinfo(self):
         # startupinfo argument
@@ -1367,7 +1367,7 @@ class Win32ProcessTestCase(BaseTestCase):
 class ProcessTestCaseNoPoll(ProcessTestCase):
     def setUp(self):
         if not getattr(subprocess, '_has_poll', False):
-            raise SkipTest('poll system call not supported')
+            self.skipTest('poll system call not supported')
         subprocess._has_poll = False
         ProcessTestCase.setUp(self)
 
@@ -1382,7 +1382,7 @@ class HelperFunctionTests(unittest.TestCase):
     #@unittest.skipIf(mswindows, "errno and EINTR make no sense on windows")
     def test_eintr_retry_call(self):
         if mswindows:
-            raise SkipTest('errno and EINTR make no sense on windows')
+            self.skipTest('errno and EINTR make no sense on windows')
         record_calls = []
         def fake_os_func(*args):
             record_calls.append(args)
@@ -1408,7 +1408,7 @@ class CommandsWithSpaces (BaseTestCase):
 
     def setUp(self):
         if not mswindows:
-            raise SkipTest('mswindows only')
+            self.skipTest('mswindows only')
 
         super(CommandsWithSpaces, self).setUp()
         f, fname = mkstemp(".py", "te st")

--- a/kitchen2/tests/test_text_display.py
+++ b/kitchen2/tests/test_text_display.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 from kitchen.text.exceptions import ControlCharError
 
@@ -14,19 +13,19 @@ class TestDisplay(base_classes.UnicodeTestData, unittest.TestCase):
     def test_internal_interval_bisearch(self):
         '''Test that we can find things in an interval table'''
         table = ((0, 3), (5, 7), (9, 10))
-        tools.assert_true(display._interval_bisearch(0, table))
-        tools.assert_true(display._interval_bisearch(1, table))
-        tools.assert_true(display._interval_bisearch(2, table))
-        tools.assert_true(display._interval_bisearch(3, table))
-        tools.assert_true(display._interval_bisearch(5, table))
-        tools.assert_true(display._interval_bisearch(6, table))
-        tools.assert_true(display._interval_bisearch(7, table))
-        tools.assert_true(display._interval_bisearch(9, table))
-        tools.assert_true(display._interval_bisearch(10, table))
-        tools.assert_false(display._interval_bisearch(-1, table))
-        tools.assert_false(display._interval_bisearch(4, table))
-        tools.assert_false(display._interval_bisearch(8, table))
-        tools.assert_false(display._interval_bisearch(11, table))
+        self.assertTrue(display._interval_bisearch(0, table))
+        self.assertTrue(display._interval_bisearch(1, table))
+        self.assertTrue(display._interval_bisearch(2, table))
+        self.assertTrue(display._interval_bisearch(3, table))
+        self.assertTrue(display._interval_bisearch(5, table))
+        self.assertTrue(display._interval_bisearch(6, table))
+        self.assertTrue(display._interval_bisearch(7, table))
+        self.assertTrue(display._interval_bisearch(9, table))
+        self.assertTrue(display._interval_bisearch(10, table))
+        self.assertFalse(display._interval_bisearch(-1, table))
+        self.assertFalse(display._interval_bisearch(4, table))
+        self.assertFalse(display._interval_bisearch(8, table))
+        self.assertFalse(display._interval_bisearch(11, table))
 
     def test_internal_generate_combining_table(self):
         '''Test that the combining table we generate is equal to or a subseet of what's in the current table
@@ -40,27 +39,27 @@ class TestDisplay(base_classes.UnicodeTestData, unittest.TestCase):
         new_table = display._generate_combining_table()
         for interval in new_table:
             if interval[0] == interval[1]:
-                tools.assert_true(display._interval_bisearch(interval[0], old_table))
+                self.assertTrue(display._interval_bisearch(interval[0], old_table))
             else:
                 for codepoint in xrange(interval[0], interval[1] + 1):
-                    tools.assert_true(display._interval_bisearch(interval[0], old_table))
+                    self.assertTrue(display._interval_bisearch(interval[0], old_table))
 
     def test_internal_ucp_width(self):
         '''Test that ucp_width returns proper width for characters'''
         for codepoint in xrange(0, 0xFFFFF + 1):
             if codepoint < 32 or (codepoint < 0xa0 and codepoint >= 0x7f):
                 # With strict on, we should raise an error
-                tools.assert_raises(ControlCharError, display._ucp_width, codepoint, 'strict')
+                self.assertRaises(ControlCharError, display._ucp_width, codepoint, 'strict')
 
                 if codepoint in (0x08, 0x1b, 0x7f, 0x94):
                     # Backspace, delete, clear delete remove one char
-                    tools.eq_(display._ucp_width(codepoint), -1)
+                    self.assertEqual(display._ucp_width(codepoint), -1)
                 else:
                     # Everything else returns 0
-                    tools.eq_(display._ucp_width(codepoint), 0)
+                    self.assertEqual(display._ucp_width(codepoint), 0)
             elif display._interval_bisearch(codepoint, display._COMBINING):
                 # Combining character
-                tools.eq_(display._ucp_width(codepoint), 0)
+                self.assertEqual(display._ucp_width(codepoint), 0)
             elif (codepoint >= 0x1100 and
                     (codepoint <= 0x115f or                     # Hangul Jamo init. consonants
                         codepoint == 0x2329 or codepoint == 0x232a or
@@ -74,87 +73,87 @@ class TestDisplay(base_classes.UnicodeTestData, unittest.TestCase):
                         (codepoint >= 0xffe0 and codepoint <= 0xffe6) or
                         (codepoint >= 0x20000 and codepoint <= 0x2fffd) or
                         (codepoint >= 0x30000 and codepoint <= 0x3fffd))):
-                tools.eq_(display._ucp_width(codepoint), 2)
+                self.assertEqual(display._ucp_width(codepoint), 2)
             else:
-                tools.eq_(display._ucp_width(codepoint), 1)
+                self.assertEqual(display._ucp_width(codepoint), 1)
 
     def test_textual_width(self):
         '''Test that we find the proper number of spaces that a utf8 string will consume'''
-        tools.eq_(display.textual_width(self.u_japanese), 31)
-        tools.eq_(display.textual_width(self.u_spanish), 50)
-        tools.eq_(display.textual_width(self.u_mixed), 23)
+        self.assertEqual(display.textual_width(self.u_japanese), 31)
+        self.assertEqual(display.textual_width(self.u_spanish), 50)
+        self.assertEqual(display.textual_width(self.u_mixed), 23)
 
     def test_textual_width_chop(self):
         '''utf8_width_chop with byte strings'''
-        tools.eq_(display.textual_width_chop(self.u_mixed, 1000), self.u_mixed)
-        tools.eq_(display.textual_width_chop(self.u_mixed, 23), self.u_mixed)
-        tools.eq_(display.textual_width_chop(self.u_mixed, 22), self.u_mixed[:-1])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:-4])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 1), u'')
-        tools.eq_(display.textual_width_chop(self.u_mixed, 2), self.u_mixed[0])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 3), self.u_mixed[:2])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 4), self.u_mixed[:3])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 5), self.u_mixed[:4])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 6), self.u_mixed[:5])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 7), self.u_mixed[:5])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 8), self.u_mixed[:6])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 9), self.u_mixed[:7])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 10), self.u_mixed[:8])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 11), self.u_mixed[:9])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 12), self.u_mixed[:10])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 13), self.u_mixed[:10])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 14), self.u_mixed[:11])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 15), self.u_mixed[:12])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 16), self.u_mixed[:13])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 17), self.u_mixed[:14])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 18), self.u_mixed[:15])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:15])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 20), self.u_mixed[:16])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 21), self.u_mixed[:17])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 1000), self.u_mixed)
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 23), self.u_mixed)
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 22), self.u_mixed[:-1])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:-4])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 1), u'')
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 2), self.u_mixed[0])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 3), self.u_mixed[:2])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 4), self.u_mixed[:3])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 5), self.u_mixed[:4])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 6), self.u_mixed[:5])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 7), self.u_mixed[:5])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 8), self.u_mixed[:6])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 9), self.u_mixed[:7])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 10), self.u_mixed[:8])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 11), self.u_mixed[:9])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 12), self.u_mixed[:10])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 13), self.u_mixed[:10])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 14), self.u_mixed[:11])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 15), self.u_mixed[:12])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 16), self.u_mixed[:13])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 17), self.u_mixed[:14])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 18), self.u_mixed[:15])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:15])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 20), self.u_mixed[:16])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 21), self.u_mixed[:17])
 
     def test_textual_width_fill(self):
         '''Pad a utf8 string'''
-        tools.eq_(display.textual_width_fill(self.u_mixed, 1), self.u_mixed)
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25), self.u_mixed + u'  ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, left=False), u'  ' + self.u_mixed)
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + u'       ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + u'       ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + u'       ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + u'       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 1), self.u_mixed)
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25), self.u_mixed + u'  ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, left=False), u'  ' + self.u_mixed)
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + u'       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + u'       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + u'       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + u'       ')
 
     def test_internal_textual_width_le(self):
         test_data = ''.join([self.u_mixed, self.u_spanish])
         tw = display.textual_width(test_data)
-        tools.eq_(display._textual_width_le(68, self.u_mixed, self.u_spanish), (tw <= 68))
-        tools.eq_(display._textual_width_le(69, self.u_mixed, self.u_spanish), (tw <= 69))
-        tools.eq_(display._textual_width_le(137, self.u_mixed, self.u_spanish), (tw <= 137))
-        tools.eq_(display._textual_width_le(138, self.u_mixed, self.u_spanish), (tw <= 138))
-        tools.eq_(display._textual_width_le(78, self.u_mixed, self.u_spanish), (tw <= 78))
-        tools.eq_(display._textual_width_le(79, self.u_mixed, self.u_spanish), (tw <= 79))
+        self.assertEqual(display._textual_width_le(68, self.u_mixed, self.u_spanish), (tw <= 68))
+        self.assertEqual(display._textual_width_le(69, self.u_mixed, self.u_spanish), (tw <= 69))
+        self.assertEqual(display._textual_width_le(137, self.u_mixed, self.u_spanish), (tw <= 137))
+        self.assertEqual(display._textual_width_le(138, self.u_mixed, self.u_spanish), (tw <= 138))
+        self.assertEqual(display._textual_width_le(78, self.u_mixed, self.u_spanish), (tw <= 78))
+        self.assertEqual(display._textual_width_le(79, self.u_mixed, self.u_spanish), (tw <= 79))
 
     def test_wrap(self):
         '''Test that text wrapping works'''
-        tools.eq_(display.wrap(self.u_mixed), [self.u_mixed])
-        tools.eq_(display.wrap(self.u_paragraph), self.u_paragraph_out)
-        tools.eq_(display.wrap(self.utf8_paragraph), self.u_paragraph_out)
-        tools.eq_(display.wrap(self.u_mixed_para), self.u_mixed_para_out)
-        tools.eq_(display.wrap(self.u_mixed_para, width=57,
+        self.assertEqual(display.wrap(self.u_mixed), [self.u_mixed])
+        self.assertEqual(display.wrap(self.u_paragraph), self.u_paragraph_out)
+        self.assertEqual(display.wrap(self.utf8_paragraph), self.u_paragraph_out)
+        self.assertEqual(display.wrap(self.u_mixed_para), self.u_mixed_para_out)
+        self.assertEqual(display.wrap(self.u_mixed_para, width=57,
             initial_indent='    ', subsequent_indent='----'),
             self.u_mixed_para_57_initial_subsequent_out)
 
     def test_fill(self):
-        tools.eq_(display.fill(self.u_paragraph), u'\n'.join(self.u_paragraph_out))
-        tools.eq_(display.fill(self.utf8_paragraph), u'\n'.join(self.u_paragraph_out))
-        tools.eq_(display.fill(self.u_mixed_para), u'\n'.join(self.u_mixed_para_out))
-        tools.eq_(display.fill(self.u_mixed_para, width=57,
+        self.assertEqual(display.fill(self.u_paragraph), u'\n'.join(self.u_paragraph_out))
+        self.assertEqual(display.fill(self.utf8_paragraph), u'\n'.join(self.u_paragraph_out))
+        self.assertEqual(display.fill(self.u_mixed_para), u'\n'.join(self.u_mixed_para_out))
+        self.assertEqual(display.fill(self.u_mixed_para, width=57,
             initial_indent='    ', subsequent_indent='----'),
             u'\n'.join(self.u_mixed_para_57_initial_subsequent_out))
 
     def test_byte_string_textual_width_fill(self):
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 1), self.utf8_mixed)
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25), self.utf8_mixed + '  ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, left=False), '  ' + self.utf8_mixed)
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + '       ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + '       ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + '       ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + '       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 1), self.utf8_mixed)
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25), self.utf8_mixed + '  ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, left=False), '  ' + self.utf8_mixed)
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + '       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + '       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + '       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + '       ')

--- a/kitchen2/tests/test_text_misc.py
+++ b/kitchen2/tests/test_text_misc.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
-from nose.plugins.skip import SkipTest
 
 try:
     import chardet
@@ -18,136 +16,136 @@ import base_classes
 class TestTextMisc(unittest.TestCase, base_classes.UnicodeTestData):
     def test_guess_encoding_no_chardet(self):
         # Test that unicode strings are not allowed
-        tools.assert_raises(TypeError, misc.guess_encoding, self.u_spanish)
+        self.assertRaises(TypeError, misc.guess_encoding, self.u_spanish)
 
-        tools.ok_(misc.guess_encoding(self.utf8_spanish, disable_chardet=True) == 'utf-8')
-        tools.ok_(misc.guess_encoding(self.latin1_spanish, disable_chardet=True) == 'latin-1')
-        tools.ok_(misc.guess_encoding(self.utf8_japanese, disable_chardet=True) == 'utf-8')
-        tools.ok_(misc.guess_encoding(self.euc_jp_japanese, disable_chardet=True) == 'latin-1')
+        self.assertTrue(misc.guess_encoding(self.utf8_spanish, disable_chardet=True) == 'utf-8')
+        self.assertTrue(misc.guess_encoding(self.latin1_spanish, disable_chardet=True) == 'latin-1')
+        self.assertTrue(misc.guess_encoding(self.utf8_japanese, disable_chardet=True) == 'utf-8')
+        self.assertTrue(misc.guess_encoding(self.euc_jp_japanese, disable_chardet=True) == 'latin-1')
 
     def test_guess_encoding_with_chardet(self):
         # We go this slightly roundabout way because multiple encodings can
         # output the same byte sequence.  What we're really interested in is
         # if we can get the original unicode string without knowing the
         # converters beforehand
-        tools.ok_(to_unicode(self.utf8_spanish,
+        self.assertTrue(to_unicode(self.utf8_spanish,
             misc.guess_encoding(self.utf8_spanish)) == self.u_spanish)
-        tools.ok_(to_unicode(self.latin1_spanish,
+        self.assertTrue(to_unicode(self.latin1_spanish,
             misc.guess_encoding(self.latin1_spanish)) == self.u_spanish)
-        tools.ok_(to_unicode(self.utf8_japanese,
+        self.assertTrue(to_unicode(self.utf8_japanese,
             misc.guess_encoding(self.utf8_japanese)) == self.u_japanese)
 
     def test_guess_encoding_with_chardet_installed(self):
         if chardet:
-            tools.ok_(to_unicode(self.euc_jp_japanese,
+            self.assertTrue(to_unicode(self.euc_jp_japanese,
                 misc.guess_encoding(self.euc_jp_japanese)) == self.u_japanese)
         else:
-            raise SkipTest('chardet not installed, euc_jp will not be guessed correctly')
+            self.skipTest('chardet not installed, euc_jp will not be guessed correctly')
 
     def test_guess_encoding_with_chardet_uninstalled(self):
         if chardet:
-            raise SkipTest('chardet installed, euc_jp will not be mangled')
+            self.skipTest('chardet installed, euc_jp will not be mangled')
         else:
-            tools.ok_(to_unicode(self.euc_jp_japanese,
+            self.assertTrue(to_unicode(self.euc_jp_japanese,
                 misc.guess_encoding(self.euc_jp_japanese)) ==
                 self.u_mangled_euc_jp_as_latin1)
 
     def test_str_eq(self):
         # str vs str:
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.euc_jp_japanese) == True)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.utf8_japanese) == True)
-        tools.ok_(misc.str_eq(self.b_ascii, self.b_ascii) == True)
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.latin1_spanish) == False)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.euc_jp_japanese) == False)
-        tools.ok_(misc.str_eq(self.b_ascii, self.b_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.euc_jp_japanese) == True)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.utf8_japanese) == True)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.b_ascii) == True)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.latin1_spanish) == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.euc_jp_japanese) == False)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.b_ascii[:-2]) == False)
 
         # unicode vs unicode:
-        tools.ok_(misc.str_eq(self.u_japanese, self.u_japanese) == True)
-        tools.ok_(misc.str_eq(self.u_ascii, self.u_ascii) == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.u_spanish) == False)
-        tools.ok_(misc.str_eq(self.u_ascii, self.u_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.u_japanese) == True)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.u_ascii) == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.u_spanish) == False)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.u_ascii[:-2]) == False)
 
         # unicode vs str with default utf-8 conversion:
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese) == True)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii) == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.euc_jp_japanese) == False)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese) == True)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii) == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.euc_jp_japanese) == False)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii[:-2]) == False)
 
         # unicode vs str with explicit encodings:
-        tools.ok_(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='euc_jp') == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='utf8') == True)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii, encoding='latin1') == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='latin1') == False)
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii[:-2], encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='euc_jp') == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='utf8') == True)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii, encoding='latin1') == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii[:-2], encoding='latin1') == False)
 
         # str vs unicode (reverse parameter order of unicode vs str)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese) == True)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii) == True)
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.u_japanese) == False)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese) == True)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii) == True)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.u_japanese) == False)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii[:-2]) == False)
 
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='euc_jp') == True)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='utf8') == True)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii, encoding='latin1') == True)
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='latin1') == False)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii[:-2], encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='euc_jp') == True)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='utf8') == True)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii, encoding='latin1') == True)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii[:-2], encoding='latin1') == False)
 
 
     def test_process_control_chars(self):
-        tools.assert_raises(TypeError, misc.process_control_chars, 'byte string')
-        tools.assert_raises(ControlCharError, misc.process_control_chars,
+        self.assertRaises(TypeError, misc.process_control_chars, 'byte string')
+        self.assertRaises(ControlCharError, misc.process_control_chars,
                 *[self.u_ascii_chars], **{'strategy': 'strict'})
-        tools.ok_(misc.process_control_chars(self.u_ascii_chars,
+        self.assertTrue(misc.process_control_chars(self.u_ascii_chars,
             strategy='ignore') == self.u_ascii_no_ctrl)
-        tools.ok_(misc.process_control_chars(self.u_ascii_chars,
+        self.assertTrue(misc.process_control_chars(self.u_ascii_chars,
             strategy='replace') == self.u_ascii_ctrl_replace)
 
     def test_html_entities_unescape(self):
-        tools.assert_raises(TypeError, misc.html_entities_unescape, 'byte string')
-        tools.ok_(misc.html_entities_unescape(self.u_entity_escape) == self.u_entity)
-        tools.ok_(misc.html_entities_unescape(u'<tag>%s</tag>'
+        self.assertRaises(TypeError, misc.html_entities_unescape, 'byte string')
+        self.assertTrue(misc.html_entities_unescape(self.u_entity_escape) == self.u_entity)
+        self.assertTrue(misc.html_entities_unescape(u'<tag>%s</tag>'
             % self.u_entity_escape) == self.u_entity)
-        tools.ok_(misc.html_entities_unescape(u'a&#1234567890;b') == u'a&#1234567890;b')
-        tools.ok_(misc.html_entities_unescape(u'a&#xfffd;b') == u'a\ufffdb')
-        tools.ok_(misc.html_entities_unescape(u'a&#65533;b') == u'a\ufffdb')
+        self.assertTrue(misc.html_entities_unescape(u'a&#1234567890;b') == u'a&#1234567890;b')
+        self.assertTrue(misc.html_entities_unescape(u'a&#xfffd;b') == u'a\ufffdb')
+        self.assertTrue(misc.html_entities_unescape(u'a&#65533;b') == u'a\ufffdb')
 
     def test_byte_string_valid_xml(self):
-        tools.ok_(misc.byte_string_valid_xml(u'unicode string') == False)
+        self.assertTrue(misc.byte_string_valid_xml(u'unicode string') == False)
 
-        tools.ok_(misc.byte_string_valid_xml(self.utf8_japanese))
-        tools.ok_(misc.byte_string_valid_xml(self.euc_jp_japanese, 'euc_jp'))
+        self.assertTrue(misc.byte_string_valid_xml(self.utf8_japanese))
+        self.assertTrue(misc.byte_string_valid_xml(self.euc_jp_japanese, 'euc_jp'))
 
-        tools.ok_(misc.byte_string_valid_xml(self.utf8_japanese, 'euc_jp') == False)
-        tools.ok_(misc.byte_string_valid_xml(self.euc_jp_japanese, 'utf8') == False)
+        self.assertTrue(misc.byte_string_valid_xml(self.utf8_japanese, 'euc_jp') == False)
+        self.assertTrue(misc.byte_string_valid_xml(self.euc_jp_japanese, 'utf8') == False)
 
-        tools.ok_(misc.byte_string_valid_xml(self.utf8_ascii_chars) == False)
+        self.assertTrue(misc.byte_string_valid_xml(self.utf8_ascii_chars) == False)
 
     def test_byte_string_valid_encoding(self):
         '''Test that a byte sequence is validated'''
-        tools.ok_(misc.byte_string_valid_encoding(self.utf8_japanese) == True)
-        tools.ok_(misc.byte_string_valid_encoding(self.euc_jp_japanese, encoding='euc_jp') == True)
+        self.assertTrue(misc.byte_string_valid_encoding(self.utf8_japanese) == True)
+        self.assertTrue(misc.byte_string_valid_encoding(self.euc_jp_japanese, encoding='euc_jp') == True)
 
     def test_byte_string_invalid_encoding(self):
         '''Test that we return False with non-encoded chars'''
-        tools.ok_(misc.byte_string_valid_encoding('\xff') == False)
-        tools.ok_(misc.byte_string_valid_encoding(self.euc_jp_japanese) == False)
+        self.assertTrue(misc.byte_string_valid_encoding('\xff') == False)
+        self.assertTrue(misc.byte_string_valid_encoding(self.euc_jp_japanese) == False)
 
 class TestIsStringTypes(unittest.TestCase):
     def test_isbasestring(self):
-        tools.assert_true(misc.isbasestring('abc'))
-        tools.assert_true(misc.isbasestring(u'abc'))
-        tools.assert_false(misc.isbasestring(5))
+        self.assertTrue(misc.isbasestring('abc'))
+        self.assertTrue(misc.isbasestring(u'abc'))
+        self.assertFalse(misc.isbasestring(5))
 
     def test_isbytestring(self):
-        tools.assert_true(misc.isbytestring('abc'))
-        tools.assert_false(misc.isbytestring(u'abc'))
-        tools.assert_false(misc.isbytestring(5))
+        self.assertTrue(misc.isbytestring('abc'))
+        self.assertFalse(misc.isbytestring(u'abc'))
+        self.assertFalse(misc.isbytestring(5))
 
     def test_isunicodestring(self):
-        tools.assert_false(misc.isunicodestring('abc'))
-        tools.assert_true(misc.isunicodestring(u'abc'))
-        tools.assert_false(misc.isunicodestring(5))
+        self.assertFalse(misc.isunicodestring('abc'))
+        self.assertTrue(misc.isunicodestring(u'abc'))
+        self.assertFalse(misc.isunicodestring(5))

--- a/kitchen2/tests/test_text_utf8.py
+++ b/kitchen2/tests/test_text_utf8.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 import warnings
 
@@ -19,9 +18,9 @@ class TestUTF8(base_classes.UnicodeTestData, unittest.TestCase):
 
     def test_utf8_width(self):
         '''Test that we find the proper number of spaces that a utf8 string will consume'''
-        tools.ok_(utf8.utf8_width(self.utf8_japanese) == 31)
-        tools.ok_(utf8.utf8_width(self.utf8_spanish) == 50)
-        tools.ok_(utf8.utf8_width(self.utf8_mixed) == 23)
+        self.assertTrue(utf8.utf8_width(self.utf8_japanese) == 31)
+        self.assertTrue(utf8.utf8_width(self.utf8_spanish) == 50)
+        self.assertTrue(utf8.utf8_width(self.utf8_mixed) == 23)
 
     def test_utf8_width_non_utf8(self):
         '''Test that we handle non-utf8 bytes in utf8_width without backtracing'''
@@ -35,58 +34,58 @@ class TestUTF8(base_classes.UnicodeTestData, unittest.TestCase):
         # El veloz murci�go salt�bre el perro perezoso.
         if len(unicode(u'\xe9la'.encode('latin1'), 'utf8', 'replace')) == 1:
             # Python < 2.7
-            tools.ok_(utf8.utf8_width(self.latin1_spanish) == 45)
+            self.assertTrue(utf8.utf8_width(self.latin1_spanish) == 45)
         else:
             # Python >= 2.7
-            tools.ok_(utf8.utf8_width(self.latin1_spanish) == 50)
+            self.assertTrue(utf8.utf8_width(self.latin1_spanish) == 50)
 
     def test_utf8_width_chop(self):
         '''utf8_width_chop with byte strings'''
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed) == (23, self.utf8_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 23) == (23, self.utf8_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 22) == (22, self.utf8_mixed[:-1]))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 19) == (18, self.u_mixed[:-4].encode('utf8')))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 2) == (2, self.u_mixed[0].encode('utf8')))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 1) == (0, ''))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed) == (23, self.utf8_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 23) == (23, self.utf8_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 22) == (22, self.utf8_mixed[:-1]))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 19) == (18, self.u_mixed[:-4].encode('utf8')))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 2) == (2, self.u_mixed[0].encode('utf8')))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 1) == (0, ''))
 
     def test_utf8_width_chop_unicode(self):
         '''utf8_width_chop with unicode input'''
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed) == (23, self.u_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 23) == (23, self.u_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 22) == (22, self.u_mixed[:-1]))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 19) == (18, self.u_mixed[:-4]))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 2) == (2, self.u_mixed[0]))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 1) == (0, u''))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed) == (23, self.u_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 23) == (23, self.u_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 22) == (22, self.u_mixed[:-1]))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 19) == (18, self.u_mixed[:-4]))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 2) == (2, self.u_mixed[0]))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 1) == (0, u''))
 
     def test_utf8_width_fill(self):
         '''Pad a utf8 string'''
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 1) == self.utf8_mixed)
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25) == self.utf8_mixed + '  ')
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, left=False) == '  ' + self.utf8_mixed)
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + '       ')
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish) == self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + '       ')
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + '       ')
-        tools.ok_(utf8.utf8_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.utf8_spanish) == self.u_spanish.encode('utf8') + self.u_mixed[:-4].encode('utf8') + self.u_spanish.encode('utf8') + '       ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 1) == self.utf8_mixed)
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25) == self.utf8_mixed + '  ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, left=False) == '  ' + self.utf8_mixed)
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + '       ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish) == self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + '       ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + '       ')
+        self.assertTrue(utf8.utf8_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.utf8_spanish) == self.u_spanish.encode('utf8') + self.u_mixed[:-4].encode('utf8') + self.u_spanish.encode('utf8') + '       ')
         pass
 
     def test_utf8_valid(self):
         '''Test that a utf8 byte sequence is validated'''
         warnings.simplefilter('ignore', DeprecationWarning)
-        tools.ok_(utf8.utf8_valid(self.utf8_japanese) == True)
-        tools.ok_(utf8.utf8_valid(self.utf8_spanish) == True)
+        self.assertTrue(utf8.utf8_valid(self.utf8_japanese) == True)
+        self.assertTrue(utf8.utf8_valid(self.utf8_spanish) == True)
         warnings.simplefilter('default', DeprecationWarning)
 
     def test_utf8_invalid(self):
         '''Test that we return False with non-utf8 chars'''
         warnings.simplefilter('ignore', DeprecationWarning)
-        tools.ok_(utf8.utf8_valid('\xff') == False)
-        tools.ok_(utf8.utf8_valid(self.latin1_spanish) == False)
+        self.assertTrue(utf8.utf8_valid('\xff') == False)
+        self.assertTrue(utf8.utf8_valid(self.latin1_spanish) == False)
         warnings.simplefilter('default', DeprecationWarning)
 
     def test_utf8_text_wrap(self):
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_mixed) == [self.utf8_mixed])
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_paragraph) == self.utf8_paragraph_out)
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_mixed_para) == self.utf8_mixed_para_out)
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_mixed_para, width=57,
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_mixed) == [self.utf8_mixed])
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_paragraph) == self.utf8_paragraph_out)
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_mixed_para) == self.utf8_mixed_para_out)
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_mixed_para, width=57,
             initial_indent='    ', subsequent_indent='----') ==
             self.utf8_mixed_para_57_initial_subsequent_out)

--- a/kitchen2/tests/test_versioning.py
+++ b/kitchen2/tests/test_versioning.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-from nose import tools
+
+import unittest
 
 from kitchen.versioning import version_tuple_to_string
 
 # Note: Using nose's generator tests for this so we can't subclass
 # unittest.TestCase
-class TestVersionTuple(object):
+class TestVersionTuple(unittest.TestCase):
     ver_to_tuple = {u'1': ((1,),),
             u'1.0': ((1, 0),),
             u'1.0.0': ((1, 0, 0),),
@@ -25,7 +26,7 @@ class TestVersionTuple(object):
             }
 
     def check_ver_tuple_to_str(self, v_tuple, v_str):
-        tools.eq_(version_tuple_to_string(v_tuple), v_str)
+        self.assertEqual(version_tuple_to_string(v_tuple), v_str)
 
     def test_version_tuple_to_string(self):
         '''Test that version_tuple_to_string outputs PEP-386 compliant strings

--- a/kitchen3/tests/test__all__.py
+++ b/kitchen3/tests/test__all__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from nose import tools
+
+import unittest
 
 import os
 import types
@@ -18,7 +19,7 @@ class NoAll(RuntimeError):
 class FailedImport(RuntimeError):
     pass
 
-class Test__all__(object):
+class Test__all__(unittest.TestCase):
     '''Test that every function in __all__ exists and that no public methods
     are missing from __all__
     '''
@@ -100,9 +101,9 @@ class Test__all__(object):
         try:
             try:
                 f = open(modpath, 'r', encoding='utf-8')
-                tools.ok_('__all__' in f.read(), '%s does not contain __all__' % modpath)
+                self.assertTrue('__all__' in f.read(), '%s does not contain __all__' % modpath)
             except IOError as e:
-                tools.ok_(False, '%s' % e)
+                self.assertTrue(False, '%s' % e)
         finally:
             if f:
                 f.close()
@@ -131,13 +132,13 @@ class Test__all__(object):
             exec('from %s.%s import *' % (modpath, modname), interior_names)
         except Exception as e:
             # Include the module name in the exception string
-            tools.ok_(False, '__all__ failure in %s: %s: %s' % (
+            self.assertTrue(False, '__all__ failure in %s: %s: %s' % (
                       modname, e.__class__.__name__, e))
         if '__builtins__' in interior_names:
             del interior_names['__builtins__']
         keys = set(interior_names)
         all = set(names[modname].__all__)
-        tools.ok_(keys == all)
+        self.assertTrue(keys == all)
 
     def test_everything_in__all__exists(self):
         '''
@@ -172,7 +173,7 @@ class Test__all__(object):
 
         all = set(mod.__all__)
         public = set(expected_public)
-        tools.ok_(all.issuperset(public), 'These public names are not in %s.__all__: %s'
+        self.assertTrue(all.issuperset(public), 'These public names are not in %s.__all__: %s'
                 % (modname, ', '.join(public.difference(all))))
 
     def test__all__is_complete(self):

--- a/kitchen3/tests/test_collections.py
+++ b/kitchen3/tests/test_collections.py
@@ -1,28 +1,28 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 from kitchen.pycompat24.sets import add_builtin_set
 add_builtin_set()
 
 from kitchen import collections
 
-def test_strict_dict_get_set():
-    '''Test getting and setting items in StrictDict'''
-    d = collections.StrictDict()
-    d['a'] = 1
-    d[b'a'] = 2
-    tools.assert_not_equal(d['a'], d[b'a'])
-    tools.eq_(len(d), 2)
+class TestStrictDictGetSet(unittest.TestCase):
+    def test_strict_dict_get_set(self):
+        '''Test getting and setting items in StrictDict'''
+        d = collections.StrictDict()
+        d['a'] = 1
+        d[b'a'] = 2
+        self.assertNotEqual(d['a'], d[b'a'])
+        self.assertEqual(len(d), 2)
 
-    d['\xf1'] = 1
-    d[b'\xf1'] = 2
-    d['\xf1'.encode('utf-8')] = 3
-    tools.eq_(d['\xf1'], 1)
-    tools.eq_(d[b'\xf1'], 2)
-    tools.eq_(d['\xf1'.encode('utf-8')], 3)
-    tools.eq_(len(d), 5)
+        d['\xf1'] = 1
+        d[b'\xf1'] = 2
+        d['\xf1'.encode('utf-8')] = 3
+        self.assertEqual(d['\xf1'], 1)
+        self.assertEqual(d[b'\xf1'], 2)
+        self.assertEqual(d['\xf1'.encode('utf-8')], 3)
+        self.assertEqual(len(d), 5)
 
 class TestStrictDict(unittest.TestCase):
     def setUp(self):
@@ -94,66 +94,66 @@ class TestStrictDict(unittest.TestCase):
 
     def test__compare_list(self):
         '''*sigh* this test support function is so complex we need to test it'''
-        tools.ok_(self._compare_lists(['a', 'b', 'c'], ['c', 'a', 'b']))
-        tools.ok_(not self._compare_lists(['b', 'c'], ['c', 'a', 'b']))
-        tools.ok_(not self._compare_lists([b'a', 'b'], ['a', 'b']))
-        tools.ok_(not self._compare_lists(['a', b'b'], [b'a', 'b']))
-        tools.ok_(self._compare_lists(['a', 'b', 1], ['a', 1, 'b']))
-        tools.ok_(self._compare_lists([b'a', b'b'], [b'a', b'b']))
-        tools.ok_(self._compare_lists([b'a', 'b'], [b'a', 'b']))
-        tools.ok_(not self._compare_lists([b'a', 'b'], [b'a', b'b']))
-        tools.ok_(self._compare_lists([b'a', 'b', 'b', 'c', b'a'], [b'a', b'a', 'b', 'c', 'b']))
-        tools.ok_(not self._compare_lists([b'a', 'b', 'b', 'c', 'a'], [b'a', b'a', 'b', 'c', 'b']))
-        tools.ok_(not self._compare_lists([b'a', 'b', 'b', 'c', b'a'], [b'a', 'b', 'b', 'c', 'b']))
+        self.assertTrue(self._compare_lists(['a', 'b', 'c'], ['c', 'a', 'b']))
+        self.assertTrue(not self._compare_lists(['b', 'c'], ['c', 'a', 'b']))
+        self.assertTrue(not self._compare_lists([b'a', 'b'], ['a', 'b']))
+        self.assertTrue(not self._compare_lists(['a', b'b'], [b'a', 'b']))
+        self.assertTrue(self._compare_lists(['a', 'b', 1], ['a', 1, 'b']))
+        self.assertTrue(self._compare_lists([b'a', b'b'], [b'a', b'b']))
+        self.assertTrue(self._compare_lists([b'a', 'b'], [b'a', 'b']))
+        self.assertTrue(not self._compare_lists([b'a', 'b'], [b'a', b'b']))
+        self.assertTrue(self._compare_lists([b'a', 'b', 'b', 'c', b'a'], [b'a', b'a', 'b', 'c', 'b']))
+        self.assertTrue(not self._compare_lists([b'a', 'b', 'b', 'c', 'a'], [b'a', b'a', 'b', 'c', 'b']))
+        self.assertTrue(not self._compare_lists([b'a', 'b', 'b', 'c', b'a'], [b'a', 'b', 'b', 'c', 'b']))
 
     def test_strict_dict_len(self):
         '''StrictDict len'''
-        tools.eq_(len(self.d), 5)
+        self.assertEqual(len(self.d), 5)
 
     def test_strict_dict_del(self):
         '''StrictDict del'''
-        tools.eq_(len(self.d), 5)
+        self.assertEqual(len(self.d), 5)
         del(self.d['\xf1'])
-        tools.assert_raises(KeyError, self.d.__getitem__, '\xf1')
-        tools.eq_(len(self.d), 4)
+        self.assertRaises(KeyError, self.d.__getitem__, '\xf1')
+        self.assertEqual(len(self.d), 4)
 
     def test_strict_dict_iter(self):
         '''StrictDict iteration'''
         keys = []
         for k in self.d:
             keys.append(k)
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
         keys = []
         for k in self.d.keys():
             keys.append(k)
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
         keys = [k for k in self.d]
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
         keys = []
         for k in list(self.d.keys()):
             keys.append(k)
-        tools.ok_(self._compare_lists(keys, self.keys),
+        self.assertTrue(self._compare_lists(keys, self.keys),
                 msg='keys != self.key: %s != %s' % (keys, self.keys))
 
     def test_strict_dict_contains(self):
         '''StrictDict contains function'''
-        tools.ok_(b'b' not in self.d)
-        tools.ok_('b' not in self.d)
-        tools.ok_(b'\xf1' in self.d)
-        tools.ok_('\xf1' in self.d)
-        tools.ok_(b'a' in self.d)
-        tools.ok_('a' in self.d)
+        self.assertTrue(b'b' not in self.d)
+        self.assertTrue('b' not in self.d)
+        self.assertTrue(b'\xf1' in self.d)
+        self.assertTrue('\xf1' in self.d)
+        self.assertTrue(b'a' in self.d)
+        self.assertTrue('a' in self.d)
 
         del(self.d['\xf1'])
-        tools.ok_('\xf1' not in self.d)
-        tools.ok_(b'\xf1' in self.d)
+        self.assertTrue('\xf1' not in self.d)
+        self.assertTrue(b'\xf1' in self.d)
 
         del(self.d[b'a'])
-        tools.ok_('a' in self.d)
-        tools.ok_(b'a' not in self.d)
+        self.assertTrue('a' in self.d)
+        self.assertTrue(b'a' not in self.d)

--- a/kitchen3/tests/test_converters.py
+++ b/kitchen3/tests/test_converters.py
@@ -2,7 +2,6 @@
 #
 
 import unittest
-from nose import tools
 from nose.plugins.skip import SkipTest
 
 import io
@@ -49,98 +48,98 @@ class ReprUnicode(object):
 class TestConverters(unittest.TestCase, base_classes.UnicodeTestData):
     def test_to_unicode(self):
         '''Test to_unicode when the user gives good values'''
-        tools.eq_(converters.to_unicode(self.u_japanese, encoding='latin1'), self.u_japanese)
+        self.assertEqual(converters.to_unicode(self.u_japanese, encoding='latin1'), self.u_japanese)
 
-        tools.eq_(converters.to_unicode(self.utf8_spanish), self.u_spanish)
-        tools.eq_(converters.to_unicode(self.utf8_japanese), self.u_japanese)
+        self.assertEqual(converters.to_unicode(self.utf8_spanish), self.u_spanish)
+        self.assertEqual(converters.to_unicode(self.utf8_japanese), self.u_japanese)
 
-        tools.eq_(converters.to_unicode(self.latin1_spanish, encoding='latin1'), self.u_spanish)
-        tools.eq_(converters.to_unicode(self.euc_jp_japanese, encoding='euc_jp'), self.u_japanese)
+        self.assertEqual(converters.to_unicode(self.latin1_spanish, encoding='latin1'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(self.euc_jp_japanese, encoding='euc_jp'), self.u_japanese)
 
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'foo'})
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'foo'})
 
     def test_to_unicode_errors(self):
-        tools.eq_(converters.to_unicode(self.latin1_spanish), self.u_mangled_spanish_latin1_as_utf8)
-        tools.eq_(converters.to_unicode(self.latin1_spanish, errors='ignore'), self.u_spanish_ignore)
-        tools.assert_raises(UnicodeDecodeError, converters.to_unicode,
+        self.assertEqual(converters.to_unicode(self.latin1_spanish), self.u_mangled_spanish_latin1_as_utf8)
+        self.assertEqual(converters.to_unicode(self.latin1_spanish, errors='ignore'), self.u_spanish_ignore)
+        self.assertRaises(UnicodeDecodeError, converters.to_unicode,
                 *[self.latin1_spanish], **{'errors': 'strict'})
 
     def test_to_unicode_nonstring(self):
-        tools.eq_(converters.to_unicode(5), '5')
-        tools.eq_(converters.to_unicode(5, nonstring='empty'), '')
-        tools.eq_(converters.to_unicode(5, nonstring='passthru'), 5)
-        tools.eq_(converters.to_unicode(5, nonstring='simplerepr'), '5')
-        tools.eq_(converters.to_unicode(5, nonstring='repr'), '5')
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'strict'})
+        self.assertEqual(converters.to_unicode(5), '5')
+        self.assertEqual(converters.to_unicode(5, nonstring='empty'), '')
+        self.assertEqual(converters.to_unicode(5, nonstring='passthru'), 5)
+        self.assertEqual(converters.to_unicode(5, nonstring='simplerepr'), '5')
+        self.assertEqual(converters.to_unicode(5, nonstring='repr'), '5')
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'nonstring': 'strict'})
 
         obj_repr = converters.to_unicode(object, nonstring='simplerepr')
-        tools.eq_(obj_repr, "<class 'object'>")
-        tools.assert_true(isinstance(obj_repr, str))
+        self.assertEqual(obj_repr, "<class 'object'>")
+        self.assertTrue(isinstance(obj_repr, str))
 
     def test_to_unicode_nonstring_with_objects_that_have__unicode__and__str__(self):
         '''Test that to_unicode handles objects that have  __unicode__ and  __str__ methods'''
         if sys.version_info < (3, 0):
             # None of these apply on python3 because python3 does not use __unicode__
             # and it enforces __str__ returning str
-            tools.eq_(converters.to_unicode(UnicodeNoStr(), nonstring='simplerepr'), self.u_spanish)
-            tools.eq_(converters.to_unicode(StrNoUnicode(), nonstring='simplerepr'), self.u_spanish)
-            tools.eq_(converters.to_unicode(UnicodeReturnsStr(), nonstring='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(UnicodeNoStr(), nonstring='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(StrNoUnicode(), nonstring='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(UnicodeReturnsStr(), nonstring='simplerepr'), self.u_spanish)
 
-        tools.eq_(converters.to_unicode(StrReturnsUnicode(), nonstring='simplerepr'), self.u_spanish)
-        tools.eq_(converters.to_unicode(UnicodeStrCrossed(), nonstring='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(StrReturnsUnicode(), nonstring='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(UnicodeStrCrossed(), nonstring='simplerepr'), self.u_spanish)
 
     def test_to_bytes(self):
         '''Test to_bytes when the user gives good values'''
-        tools.eq_(converters.to_bytes(self.utf8_japanese, encoding='latin1'), self.utf8_japanese)
+        self.assertEqual(converters.to_bytes(self.utf8_japanese, encoding='latin1'), self.utf8_japanese)
 
-        tools.eq_(converters.to_bytes(self.u_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_bytes(self.u_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_bytes(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(self.u_japanese), self.utf8_japanese)
 
-        tools.eq_(converters.to_bytes(self.u_spanish, encoding='latin1'), self.latin1_spanish)
-        tools.eq_(converters.to_bytes(self.u_japanese, encoding='euc_jp'), self.euc_jp_japanese)
+        self.assertEqual(converters.to_bytes(self.u_spanish, encoding='latin1'), self.latin1_spanish)
+        self.assertEqual(converters.to_bytes(self.u_japanese, encoding='euc_jp'), self.euc_jp_japanese)
 
     def test_to_bytes_errors(self):
-        tools.eq_(converters.to_bytes(self.u_mixed, encoding='latin1'),
+        self.assertEqual(converters.to_bytes(self.u_mixed, encoding='latin1'),
                 self.latin1_mixed_replace)
-        tools.eq_(converters.to_bytes(self.u_mixed, encoding='latin',
+        self.assertEqual(converters.to_bytes(self.u_mixed, encoding='latin',
             errors='ignore'), self.latin1_mixed_ignore)
-        tools.assert_raises(UnicodeEncodeError, converters.to_bytes,
+        self.assertRaises(UnicodeEncodeError, converters.to_bytes,
             *[self.u_mixed], **{'errors': 'strict', 'encoding': 'latin1'})
 
     def _check_repr_bytes(self, repr_string, obj_name):
-        tools.assert_true(isinstance(repr_string, bytes))
+        self.assertTrue(isinstance(repr_string, bytes))
         match = self.repr_re.match(repr_string)
-        tools.assert_not_equal(match, None)
-        tools.eq_(match.groups()[0], obj_name)
+        self.assertNotEqual(match, None)
+        self.assertEqual(match.groups()[0], obj_name)
 
     def test_to_bytes_nonstring(self):
-        tools.eq_(converters.to_bytes(5), b'5')
-        tools.eq_(converters.to_bytes(5, nonstring='empty'), b'')
-        tools.eq_(converters.to_bytes(5, nonstring='passthru'), 5)
-        tools.eq_(converters.to_bytes(5, nonstring='simplerepr'), b'5')
-        tools.eq_(converters.to_bytes(5, nonstring='repr'), b'5')
+        self.assertEqual(converters.to_bytes(5), b'5')
+        self.assertEqual(converters.to_bytes(5, nonstring='empty'), b'')
+        self.assertEqual(converters.to_bytes(5, nonstring='passthru'), 5)
+        self.assertEqual(converters.to_bytes(5, nonstring='simplerepr'), b'5')
+        self.assertEqual(converters.to_bytes(5, nonstring='repr'), b'5')
 
         # Raise a TypeError if the msg is nonstring and we're set to strict
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'strict'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'strict'})
         # Raise a TypeError if given an invalid nonstring arg
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'INVALID'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'nonstring': 'INVALID'})
 
         obj_repr = converters.to_bytes(object, nonstring='simplerepr')
-        tools.eq_(obj_repr, b"<class 'object'>")
-        tools.assert_true(isinstance(obj_repr, bytes))
+        self.assertEqual(obj_repr, b"<class 'object'>")
+        self.assertTrue(isinstance(obj_repr, bytes))
 
     def test_to_bytes_nonstring_with_objects_that_have__unicode__and__str__(self):
         if sys.version_info < (3, 0):
             # This object's _str__ returns a utf8 encoded object
-            tools.eq_(converters.to_bytes(StrNoUnicode(), nonstring='simplerepr'), self.utf8_spanish)
+            self.assertEqual(converters.to_bytes(StrNoUnicode(), nonstring='simplerepr'), self.utf8_spanish)
         # No __str__ method so this returns repr
         string = converters.to_bytes(UnicodeNoStr(), nonstring='simplerepr')
         self._check_repr_bytes(string, b'UnicodeNoStr')
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(), nonstring='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(), nonstring='simplerepr'), self.utf8_spanish)
         # Unless we explicitly ask for something different
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(),
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(),
             nonstring='simplerepr', encoding='latin1'), self.latin1_spanish)
 
         # This object has no __str__ so it returns repr
@@ -148,79 +147,79 @@ class TestConverters(unittest.TestCase, base_classes.UnicodeTestData):
         self._check_repr_bytes(string, b'UnicodeReturnsStr')
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(UnicodeStrCrossed(), nonstring='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(UnicodeStrCrossed(), nonstring='simplerepr'), self.utf8_spanish)
 
         # This object's __repr__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(ReprUnicode(), nonstring='simplerepr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), nonstring='simplerepr'),
                 'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
-        tools.eq_(converters.to_bytes(ReprUnicode(), nonstring='repr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), nonstring='repr'),
                 'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
 
     def test_unicode_to_xml(self):
-        tools.eq_(converters.unicode_to_xml(None), b'')
-        tools.assert_raises(XmlEncodeError, converters.unicode_to_xml, *[b'byte string'])
-        tools.assert_raises(ValueError, converters.unicode_to_xml, *['string'], **{'control_chars': 'foo'})
-        tools.assert_raises(XmlEncodeError, converters.unicode_to_xml,
+        self.assertEqual(converters.unicode_to_xml(None), b'')
+        self.assertRaises(XmlEncodeError, converters.unicode_to_xml, *[b'byte string'])
+        self.assertRaises(ValueError, converters.unicode_to_xml, *['string'], **{'control_chars': 'foo'})
+        self.assertRaises(XmlEncodeError, converters.unicode_to_xml,
                 *['string\u0002'], **{'control_chars': 'strict'})
-        tools.eq_(converters.unicode_to_xml(self.u_entity), self.utf8_entity_escape)
-        tools.eq_(converters.unicode_to_xml(self.u_entity, attrib=True), self.utf8_attrib_escape)
-        tools.eq_(converters.unicode_to_xml(self.u_entity, encoding='ascii'), self.ascii_entity_escape)
-        tools.eq_(converters.unicode_to_xml(self.u_entity, encoding='ascii', attrib=True), self.ascii_attrib_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity, attrib=True), self.utf8_attrib_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity, encoding='ascii'), self.ascii_entity_escape)
+        self.assertEqual(converters.unicode_to_xml(self.u_entity, encoding='ascii', attrib=True), self.ascii_attrib_escape)
 
     def test_xml_to_unicode(self):
-        tools.eq_(converters.xml_to_unicode(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity)
-        tools.eq_(converters.xml_to_unicode(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity)
-        tools.eq_(converters.xml_to_unicode(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity)
-        tools.eq_(converters.xml_to_unicode(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity)
+        self.assertEqual(converters.xml_to_unicode(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity)
 
     def test_xml_to_byte_string(self):
-        tools.eq_(converters.xml_to_byte_string(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
-        tools.eq_(converters.xml_to_byte_string(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_entity_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_attrib_escape, 'utf8', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_entity_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_attrib_escape, 'ascii', 'replace'), self.u_entity.encode('utf8'))
 
-        tools.eq_(converters.xml_to_byte_string(self.utf8_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_attrib_escape,
             output_encoding='euc_jp', errors='replace'),
             self.u_entity.encode('euc_jp', 'replace'))
-        tools.eq_(converters.xml_to_byte_string(self.utf8_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.utf8_attrib_escape,
             output_encoding='latin1', errors='replace'),
             self.u_entity.encode('latin1', 'replace'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_attrib_escape,
             output_encoding='euc_jp', errors='replace'),
             self.u_entity.encode('euc_jp', 'replace'))
-        tools.eq_(converters.xml_to_byte_string(self.ascii_attrib_escape,
+        self.assertEqual(converters.xml_to_byte_string(self.ascii_attrib_escape,
             output_encoding='latin1', errors='replace'),
             self.u_entity.encode('latin1', 'replace'))
 
     def test_byte_string_to_xml(self):
-        tools.assert_raises(XmlEncodeError, converters.byte_string_to_xml, *['test'])
-        tools.eq_(converters.byte_string_to_xml(self.utf8_entity), self.utf8_entity_escape)
-        tools.eq_(converters.byte_string_to_xml(self.utf8_entity, attrib=True), self.utf8_attrib_escape)
+        self.assertRaises(XmlEncodeError, converters.byte_string_to_xml, *['test'])
+        self.assertEqual(converters.byte_string_to_xml(self.utf8_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.byte_string_to_xml(self.utf8_entity, attrib=True), self.utf8_attrib_escape)
 
     def test_bytes_to_xml(self):
-        tools.eq_(converters.bytes_to_xml(self.b_byte_chars), self.b_byte_encoded)
+        self.assertEqual(converters.bytes_to_xml(self.b_byte_chars), self.b_byte_encoded)
 
     def test_xml_to_bytes(self):
-        tools.eq_(converters.xml_to_bytes(self.b_byte_encoded), self.b_byte_chars)
+        self.assertEqual(converters.xml_to_bytes(self.b_byte_encoded), self.b_byte_chars)
 
     def test_guess_encoding_to_xml(self):
-        tools.eq_(converters.guess_encoding_to_xml(self.u_entity), self.utf8_entity_escape)
-        tools.eq_(converters.guess_encoding_to_xml(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(converters.guess_encoding_to_xml(self.latin1_spanish), self.utf8_spanish)
-        tools.eq_(converters.guess_encoding_to_xml(self.utf8_japanese), self.utf8_japanese)
+        self.assertEqual(converters.guess_encoding_to_xml(self.u_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.guess_encoding_to_xml(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.guess_encoding_to_xml(self.latin1_spanish), self.utf8_spanish)
+        self.assertEqual(converters.guess_encoding_to_xml(self.utf8_japanese), self.utf8_japanese)
 
     def test_guess_encoding_to_xml_euc_japanese(self):
         if chardet:
-            tools.eq_(converters.guess_encoding_to_xml(self.euc_jp_japanese),
+            self.assertEqual(converters.guess_encoding_to_xml(self.euc_jp_japanese),
                     self.utf8_japanese)
         else:
-            raise SkipTest('chardet not installed, euc_japanese won\'t be detected')
+            self.skipTest('chardet not installed, euc_japanese won\'t be detected')
 
     def test_guess_encoding_to_xml_euc_japanese_mangled(self):
         if chardet:
-            raise SkipTest('chardet installed, euc_japanese won\'t be mangled')
+            self.skipTest('chardet installed, euc_japanese won\'t be mangled')
         else:
-            tools.eq_(converters.guess_encoding_to_xml(self.euc_jp_japanese),
+            self.assertEqual(converters.guess_encoding_to_xml(self.euc_jp_japanese),
                     self.utf8_mangled_euc_jp_as_latin1)
 
 class TestGetWriter(unittest.TestCase, base_classes.UnicodeTestData):
@@ -233,27 +232,27 @@ class TestGetWriter(unittest.TestCase, base_classes.UnicodeTestData):
         io.write(self.u_japanese + '\n')
         io.seek(0)
         result = io.read().strip()
-        tools.eq_(result, self.utf8_japanese)
+        self.assertEqual(result, self.utf8_japanese)
 
         io.seek(0)
         io.truncate(0)
         io.write(self.euc_jp_japanese + b'\n')
         io.seek(0)
         result = io.read().strip()
-        tools.eq_(result, self.euc_jp_japanese)
+        self.assertEqual(result, self.euc_jp_japanese)
 
         io.seek(0)
         io.truncate(0)
         io.write(self.utf8_japanese + b'\n')
         io.seek(0)
         result = io.read().strip()
-        tools.eq_(result, self.utf8_japanese)
+        self.assertEqual(result, self.utf8_japanese)
 
     def test_error_handlers(self):
         '''Test setting alternate error handlers'''
         writer = converters.getwriter('latin1')
         io = writer(self.io, errors='strict')
-        tools.assert_raises(UnicodeEncodeError, io.write, self.u_japanese)
+        self.assertRaises(UnicodeEncodeError, io.write, self.u_japanese)
 
 
 class TestExceptionConverters(unittest.TestCase, base_classes.UnicodeTestData):
@@ -273,61 +272,61 @@ class TestExceptionConverters(unittest.TestCase, base_classes.UnicodeTestData):
                 pass
 
     def test_exception_to_unicode_with_unicode(self):
-        tools.eq_(converters.exception_to_unicode(self.exceptions['u_jpn']), self.u_japanese)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['u_spanish']), self.u_spanish)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['u_jpn']), self.u_japanese)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['u_spanish']), self.u_spanish)
 
     def test_exception_to_unicode_with_bytes(self):
-        tools.eq_(converters.exception_to_unicode(self.exceptions['utf8_jpn']), self.u_japanese)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['utf8_spanish']), self.u_spanish)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['utf8_jpn']), self.u_japanese)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['utf8_spanish']), self.u_spanish)
         # Mangled latin1/utf8 conversion but no tracebacks
-        tools.eq_(converters.exception_to_unicode(self.exceptions['latin1_spanish']), self.u_mangled_spanish_latin1_as_utf8)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['latin1_spanish']), self.u_mangled_spanish_latin1_as_utf8)
         # Mangled euc_jp/utf8 conversion but no tracebacks
-        tools.eq_(converters.exception_to_unicode(self.exceptions['euc_jpn']), self.u_mangled_euc_jp_as_utf8)
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['euc_jpn']), self.u_mangled_euc_jp_as_utf8)
 
     def test_exception_to_unicode_custom(self):
         # If given custom functions, then we should not mangle
         c = [lambda e: converters.to_unicode(e.args[0], encoding='euc_jp'),
                 lambda e: converters.to_unicode(e, encoding='euc_jp')]
-        tools.eq_(converters.exception_to_unicode(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['euc_jpn'],
             converters=c), self.u_japanese)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['euc_jpn'],
             converters=c), self.u_japanese)
 
         c = [lambda e: converters.to_unicode(e.args[0], encoding='latin1'),
                 lambda e: converters.to_unicode(e, encoding='latin1')]
-        tools.eq_(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
             converters=c),  self.u_spanish)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_unicode(self.exceptions['latin1_spanish'],
             converters=c),  self.u_spanish)
 
     def test_exception_to_bytes_with_unicode(self):
-        tools.eq_(converters.exception_to_bytes(self.exceptions['u_jpn']), self.utf8_japanese)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['u_spanish']), self.utf8_spanish)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['u_jpn']), self.utf8_japanese)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['u_spanish']), self.utf8_spanish)
 
     def test_exception_to_bytes_with_bytes(self):
-        tools.eq_(converters.exception_to_bytes(self.exceptions['utf8_jpn']), self.utf8_japanese)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['utf8_spanish']), self.utf8_spanish)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['latin1_spanish']), self.latin1_spanish)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['euc_jpn']), self.euc_jp_japanese)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['utf8_jpn']), self.utf8_japanese)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['utf8_spanish']), self.utf8_spanish)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['latin1_spanish']), self.latin1_spanish)
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['euc_jpn']), self.euc_jp_japanese)
 
     def test_exception_to_bytes_custom(self):
         # If given custom functions, then we should not mangle
         c = [lambda e: converters.to_bytes(e.args[0], encoding='euc_jp'),
                 lambda e: converters.to_bytes(e, encoding='euc_jp')]
-        tools.eq_(converters.exception_to_bytes(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['euc_jpn'],
             converters=c), self.euc_jp_japanese)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['euc_jpn'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['euc_jpn'],
             converters=c), self.euc_jp_japanese)
 
         c = [lambda e: converters.to_bytes(e.args[0], encoding='latin1'),
                 lambda e: converters.to_bytes(e, encoding='latin1')]
-        tools.eq_(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
             converters=c),  self.latin1_spanish)
         c.extend(converters.EXCEPTION_CONVERTERS)
-        tools.eq_(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
+        self.assertEqual(converters.exception_to_bytes(self.exceptions['latin1_spanish'],
             converters=c),  self.latin1_spanish)
 
 
@@ -339,53 +338,53 @@ class TestDeprecatedConverters(TestConverters):
         warnings.simplefilter('default', DeprecationWarning)
 
     def test_to_xml(self):
-        tools.eq_(converters.to_xml(self.u_entity), self.utf8_entity_escape)
-        tools.eq_(converters.to_xml(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_xml(self.latin1_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_xml(self.utf8_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_xml(self.u_entity), self.utf8_entity_escape)
+        self.assertEqual(converters.to_xml(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_xml(self.latin1_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_xml(self.utf8_japanese), self.utf8_japanese)
 
     def test_to_utf8(self):
-        tools.eq_(converters.to_utf8(self.u_japanese), self.utf8_japanese)
-        tools.eq_(converters.to_utf8(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_utf8(self.u_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_utf8(self.utf8_spanish), self.utf8_spanish)
 
     def test_to_str(self):
-        tools.eq_(converters.to_str(self.u_japanese), self.utf8_japanese)
-        tools.eq_(converters.to_str(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(converters.to_str(object), b"<class 'object'>")
+        self.assertEqual(converters.to_str(self.u_japanese), self.utf8_japanese)
+        self.assertEqual(converters.to_str(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(converters.to_str(object), b"<class 'object'>")
 
     def test_non_string(self):
         '''Test deprecated non_string parameter'''
         # unicode
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'non_string': 'foo'})
-        tools.eq_(converters.to_unicode(5, non_string='empty'), '')
-        tools.eq_(converters.to_unicode(5, non_string='passthru'), 5)
-        tools.eq_(converters.to_unicode(5, non_string='simplerepr'), '5')
-        tools.eq_(converters.to_unicode(5, non_string='repr'), '5')
-        tools.assert_raises(TypeError, converters.to_unicode, *[5], **{'non_string': 'strict'})
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'non_string': 'foo'})
+        self.assertEqual(converters.to_unicode(5, non_string='empty'), '')
+        self.assertEqual(converters.to_unicode(5, non_string='passthru'), 5)
+        self.assertEqual(converters.to_unicode(5, non_string='simplerepr'), '5')
+        self.assertEqual(converters.to_unicode(5, non_string='repr'), '5')
+        self.assertRaises(TypeError, converters.to_unicode, *[5], **{'non_string': 'strict'})
 
-        tools.eq_(converters.to_unicode(StrReturnsUnicode(), non_string='simplerepr'), self.u_spanish)
-        tools.eq_(converters.to_unicode(UnicodeStrCrossed(), non_string='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(StrReturnsUnicode(), non_string='simplerepr'), self.u_spanish)
+        self.assertEqual(converters.to_unicode(UnicodeStrCrossed(), non_string='simplerepr'), self.u_spanish)
         if sys.version_info < (3, 0):
             # Not applicable on python3
-            tools.eq_(converters.to_unicode(UnicodeNoStr(), non_string='simplerepr'), self.u_spanish)
-            tools.eq_(converters.to_unicode(StrNoUnicode(), non_string='simplerepr'), self.u_spanish)
-            tools.eq_(converters.to_unicode(UnicodeReturnsStr(), non_string='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(UnicodeNoStr(), non_string='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(StrNoUnicode(), non_string='simplerepr'), self.u_spanish)
+            self.assertEqual(converters.to_unicode(UnicodeReturnsStr(), non_string='simplerepr'), self.u_spanish)
 
         obj_repr = converters.to_unicode(object, non_string='simplerepr')
-        tools.eq_(obj_repr, "<class 'object'>")
-        tools.assert_true(isinstance(obj_repr, str))
+        self.assertEqual(obj_repr, "<class 'object'>")
+        self.assertTrue(isinstance(obj_repr, str))
 
         # Bytes
-        tools.eq_(converters.to_bytes(5), b'5')
-        tools.eq_(converters.to_bytes(5, non_string='empty'), b'')
-        tools.eq_(converters.to_bytes(5, non_string='passthru'), 5)
-        tools.eq_(converters.to_bytes(5, non_string='simplerepr'), b'5')
-        tools.eq_(converters.to_bytes(5, non_string='repr'), b'5')
+        self.assertEqual(converters.to_bytes(5), b'5')
+        self.assertEqual(converters.to_bytes(5, non_string='empty'), b'')
+        self.assertEqual(converters.to_bytes(5, non_string='passthru'), 5)
+        self.assertEqual(converters.to_bytes(5, non_string='simplerepr'), b'5')
+        self.assertEqual(converters.to_bytes(5, non_string='repr'), b'5')
 
         # Raise a TypeError if the msg is non_string and we're set to strict
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'non_string': 'strict'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'non_string': 'strict'})
         # Raise a TypeError if given an invalid non_string arg
-        tools.assert_raises(TypeError, converters.to_bytes, *[5], **{'non_string': 'INVALID'})
+        self.assertRaises(TypeError, converters.to_bytes, *[5], **{'non_string': 'INVALID'})
 
         # No __str__ method so this returns repr
         string = converters.to_bytes(UnicodeNoStr(), non_string='simplerepr')
@@ -394,12 +393,12 @@ class TestDeprecatedConverters(TestConverters):
         if sys.version_info < (3, 0):
             # Not applicable on python3
             # This object's _str__ returns a utf8 encoded object
-            tools.eq_(converters.to_bytes(StrNoUnicode(), non_string='simplerepr'), self.utf8_spanish)
+            self.assertEqual(converters.to_bytes(StrNoUnicode(), non_string='simplerepr'), self.utf8_spanish)
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(), non_string='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(), non_string='simplerepr'), self.utf8_spanish)
         # Unless we explicitly ask for something different
-        tools.eq_(converters.to_bytes(StrReturnsUnicode(),
+        self.assertEqual(converters.to_bytes(StrReturnsUnicode(),
             non_string='simplerepr', encoding='latin1'), self.latin1_spanish)
 
         # This object has no __str__ so it returns repr
@@ -407,14 +406,14 @@ class TestDeprecatedConverters(TestConverters):
         self._check_repr_bytes(string, b'UnicodeReturnsStr')
 
         # This object's __str__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(UnicodeStrCrossed(), non_string='simplerepr'), self.utf8_spanish)
+        self.assertEqual(converters.to_bytes(UnicodeStrCrossed(), non_string='simplerepr'), self.utf8_spanish)
 
         # This object's __repr__ returns unicode which to_bytes converts to utf8
-        tools.eq_(converters.to_bytes(ReprUnicode(), non_string='simplerepr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), non_string='simplerepr'),
                 'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
-        tools.eq_(converters.to_bytes(ReprUnicode(), non_string='repr'),
+        self.assertEqual(converters.to_bytes(ReprUnicode(), non_string='repr'),
                 'ReprUnicode(El veloz murciélago saltó sobre el perro perezoso.)'.encode('utf8'))
 
         obj_repr = converters.to_bytes(object, non_string='simplerepr')
-        tools.eq_(obj_repr, b"<class 'object'>")
-        tools.assert_true(isinstance(obj_repr, bytes))
+        self.assertEqual(obj_repr, b"<class 'object'>")
+        self.assertTrue(isinstance(obj_repr, bytes))

--- a/kitchen3/tests/test_converters.py
+++ b/kitchen3/tests/test_converters.py
@@ -2,7 +2,6 @@
 #
 
 import unittest
-from nose.plugins.skip import SkipTest
 
 import io
 import sys

--- a/kitchen3/tests/test_deprecation.py
+++ b/kitchen3/tests/test_deprecation.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 import sys
 import warnings
@@ -21,27 +20,27 @@ class TestDeprecated(unittest.TestCase):
 
     def test_deprecated_functions(self):
         '''Test that all deprecated functions raise DeprecationWarning'''
-        tools.assert_raises(DeprecationWarning, converters.to_utf8, 'café')
-        tools.assert_raises(DeprecationWarning, converters.to_str, 5)
-        tools.assert_raises(DeprecationWarning, converters.to_xml, 'test')
+        self.assertRaises(DeprecationWarning, converters.to_utf8, 'café')
+        self.assertRaises(DeprecationWarning, converters.to_str, 5)
+        self.assertRaises(DeprecationWarning, converters.to_xml, 'test')
 
-        tools.assert_raises(DeprecationWarning, utf8.utf8_valid, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_width, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_width_chop, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_width_fill, 'test', 'asd')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_text_wrap, 'test')
-        tools.assert_raises(DeprecationWarning, utf8.utf8_text_fill, 'test')
-        tools.assert_raises(DeprecationWarning, utf8._utf8_width_le, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_valid, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_width, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_width_chop, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_width_fill, 'test', 'asd')
+        self.assertRaises(DeprecationWarning, utf8.utf8_text_wrap, 'test')
+        self.assertRaises(DeprecationWarning, utf8.utf8_text_fill, 'test')
+        self.assertRaises(DeprecationWarning, utf8._utf8_width_le, 'test')
 
     def test_deprecated_parameters(self):
-        tools.assert_raises(DeprecationWarning, converters.to_unicode, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_unicode, *[5],
                 **{'non_string': 'simplerepr'})
-        tools.assert_raises(DeprecationWarning, converters.to_unicode, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_unicode, *[5],
                 **{'nonstring': 'simplerepr', 'non_string': 'simplerepr'})
 
-        tools.assert_raises(DeprecationWarning, converters.to_bytes, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_bytes, *[5],
                 **{'non_string': 'simplerepr'})
-        tools.assert_raises(DeprecationWarning, converters.to_bytes, *[5],
+        self.assertRaises(DeprecationWarning, converters.to_bytes, *[5],
                 **{'nonstring': 'simplerepr', 'non_string': 'simplerepr'})
 
 
@@ -57,7 +56,7 @@ class TestPendingDeprecationParameters(unittest.TestCase):
 
     def test_parameters(self):
         # test that we warn when using the python2_api parameters
-        tools.assert_raises(PendingDeprecationWarning,
+        self.assertRaises(PendingDeprecationWarning,
                 i18n.get_translation_object, 'test', **{'python2_api': True})
-        tools.assert_raises(PendingDeprecationWarning,
+        self.assertRaises(PendingDeprecationWarning,
                 i18n.DummyTranslations, **{'python2_api': True})

--- a/kitchen3/tests/test_deprecation_py3.py
+++ b/kitchen3/tests/test_deprecation_py3.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from nose import tools
+import unittest
 
 import sys
 import warnings
@@ -8,8 +8,8 @@ import warnings
 import importlib
 from kitchen.pycompat25.collections import defaultdict
 
-class TestPendingDeprecationModules(object):
-    def __init__(self):
+class TestPendingDeprecationModules(unittest.TestCase):
+    def setUp(self):
         kitchen_path = 'kitchen'
         collections_path = 'kitchen/collections'
         pycompat24_path = 'kitchen/pycompat24'
@@ -46,7 +46,7 @@ class TestPendingDeprecationModules(object):
                         ('%s is deprecated' % module_name) in warning.args[0]:
                     warning_raised = True
                     break
-            tools.assert_true(warning_raised, msg='%s did not raise a PendingDeprecationWarning' % module_fqn)
+            self.assertTrue(warning_raised, msg='%s did not raise a PendingDeprecationWarning' % module_fqn)
 
     def test_modules(self):
         for mod in self.module_data:
@@ -62,4 +62,4 @@ class TestPendingDeprecationModules(object):
                         ('defaultdict is deprecated') in warning.args[0]:
                     warning_raised = True
                     break
-            tools.assert_true(warning_raised, msg='kitchen.pycompat25.collections.defaultdict did not raise a PendingDeprecationWarning')
+            self.assertTrue(warning_raised, msg='kitchen.pycompat25.collections.defaultdict did not raise a PendingDeprecationWarning')

--- a/kitchen3/tests/test_i18n.py
+++ b/kitchen3/tests/test_i18n.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 import os
 import types
@@ -31,17 +30,17 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
         '''
         _, N_ = i18n.easy_gettext_setup('foo', localedirs=
                 ['%s/data/locale/' % os.path.dirname(__file__)])
-        tools.assert_true(isinstance(_, types.MethodType))
-        tools.assert_true(isinstance(N_, types.MethodType))
-        tools.eq_(_.__name__, '_ugettext')
-        tools.eq_(N_.__name__, '_ungettext')
+        self.assertTrue(isinstance(_, types.MethodType))
+        self.assertTrue(isinstance(N_, types.MethodType))
+        self.assertEqual(_.__name__, '_ugettext')
+        self.assertEqual(N_.__name__, '_ungettext')
 
-        tools.eq_(_(self.utf8_spanish), self.u_spanish)
-        tools.eq_(_(self.u_spanish), self.u_spanish)
-        tools.eq_(N_(self.utf8_limao, self.utf8_limoes, 1), self.u_limao)
-        tools.eq_(N_(self.utf8_limao, self.utf8_limoes, 2), self.u_limoes)
-        tools.eq_(N_(self.u_limao, self.u_limoes, 1), self.u_limao)
-        tools.eq_(N_(self.u_limao, self.u_limoes, 2), self.u_limoes)
+        self.assertEqual(_(self.utf8_spanish), self.u_spanish)
+        self.assertEqual(_(self.u_spanish), self.u_spanish)
+        self.assertEqual(N_(self.utf8_limao, self.utf8_limoes, 1), self.u_limao)
+        self.assertEqual(N_(self.utf8_limao, self.utf8_limoes, 2), self.u_limoes)
+        self.assertEqual(N_(self.u_limao, self.u_limoes, 1), self.u_limao)
+        self.assertEqual(N_(self.u_limao, self.u_limoes, 2), self.u_limoes)
 
     def test_easy_gettext_setup_non_unicode(self):
         '''Test that the easy_gettext_setup function works
@@ -49,35 +48,35 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
         b_, bN_ = i18n.easy_gettext_setup('foo', localedirs=
                 ['%s/data/locale/' % os.path.dirname(__file__)],
                 use_unicode=False)
-        tools.assert_true(isinstance(b_, types.MethodType))
-        tools.assert_true(isinstance(bN_, types.MethodType))
-        tools.eq_(b_.__name__, '_lgettext')
-        tools.eq_(bN_.__name__, '_lngettext')
+        self.assertTrue(isinstance(b_, types.MethodType))
+        self.assertTrue(isinstance(bN_, types.MethodType))
+        self.assertEqual(b_.__name__, '_lgettext')
+        self.assertEqual(bN_.__name__, '_lngettext')
 
-        tools.eq_(b_(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(b_(self.u_spanish), self.utf8_spanish)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 1), self.utf8_limao)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 2), self.utf8_limoes)
+        self.assertEqual(b_(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(b_(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 1), self.utf8_limao)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 2), self.utf8_limoes)
 
     def test_get_translation_object(self):
         '''Test that the get_translation_object function works
         '''
         translations = i18n.get_translation_object('foo', ['%s/data/locale/' % os.path.dirname(__file__)])
-        tools.eq_(translations.__class__, i18n.DummyTranslations)
-        tools.assert_raises(IOError, i18n.get_translation_object, 'foo', ['%s/data/locale/' % os.path.dirname(__file__)], fallback=False)
+        self.assertEqual(translations.__class__, i18n.DummyTranslations)
+        self.assertRaises(IOError, i18n.get_translation_object, 'foo', ['%s/data/locale/' % os.path.dirname(__file__)], fallback=False)
 
         translations = i18n.get_translation_object('test', ['%s/data/locale/' % os.path.dirname(__file__)])
-        tools.eq_(translations.__class__, i18n.NewGNUTranslations)
+        self.assertEqual(translations.__class__, i18n.NewGNUTranslations)
 
     def test_get_translation_object_create_fallback(self):
         '''Test get_translation_object creates fallbacks for additional catalogs'''
         translations = i18n.get_translation_object('test',
                 ['%s/data/locale' % os.path.dirname(__file__),
                     '%s/data/locale-old' % os.path.dirname(__file__)])
-        tools.eq_(translations.__class__, i18n.NewGNUTranslations)
-        tools.eq_(translations._fallback.__class__, i18n.NewGNUTranslations)
+        self.assertEqual(translations.__class__, i18n.NewGNUTranslations)
+        self.assertEqual(translations._fallback.__class__, i18n.NewGNUTranslations)
 
     def test_get_translation_object_copy(self):
         '''Test get_translation_object shallow copies the message catalog'''
@@ -93,16 +92,16 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
         # Test that portions of the translation objects are the same and other
         # portions are different (which is a space optimization so that the
         # translation data isn't in memory multiple times)
-        tools.assert_not_equal(id(translations._fallback), id(translations2._fallback))
-        tools.assert_not_equal(id(translations.output_charset()), id(translations2.output_charset()))
-        tools.assert_not_equal(id(translations.input_charset), id(translations2.input_charset))
-        tools.assert_not_equal(id(translations.input_charset), id(translations2.input_charset))
-        tools.eq_(id(translations._catalog), id(translations2._catalog))
+        self.assertNotEqual(id(translations._fallback), id(translations2._fallback))
+        self.assertNotEqual(id(translations.output_charset()), id(translations2.output_charset()))
+        self.assertNotEqual(id(translations.input_charset), id(translations2.input_charset))
+        self.assertNotEqual(id(translations.input_charset), id(translations2.input_charset))
+        self.assertEqual(id(translations._catalog), id(translations2._catalog))
 
     def test_get_translation_object_optional_params(self):
         '''Smoketest leaving out optional parameters'''
         translations = i18n.get_translation_object('test')
-        tools.assert_true(translations.__class__ in (i18n.NewGNUTranslations, i18n.DummyTranslations))
+        self.assertTrue(translations.__class__ in (i18n.NewGNUTranslations, i18n.DummyTranslations))
 
     def test_get_translation_object_python2_api_default(self):
         '''Smoketest that python2_api default value yields the python2 functions'''
@@ -111,12 +110,12 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
                 ['%s/data/locale' % os.path.dirname(__file__),
                     '%s/data/locale-old' % os.path.dirname(__file__)], codeset='utf-8')
         translations.input_charset = 'utf-8'
-        tools.eq_(translations.gettext.__name__, '_gettext')
-        tools.eq_(translations.lgettext.__name__, '_lgettext')
-        tools.eq_(translations.ugettext.__name__, '_ugettext')
-        tools.eq_(translations.ngettext.__name__, '_ngettext')
-        tools.eq_(translations.lngettext.__name__, '_lngettext')
-        tools.eq_(translations.ungettext.__name__, '_ungettext')
+        self.assertEqual(translations.gettext.__name__, '_gettext')
+        self.assertEqual(translations.lgettext.__name__, '_lgettext')
+        self.assertEqual(translations.ugettext.__name__, '_ugettext')
+        self.assertEqual(translations.ngettext.__name__, '_ngettext')
+        self.assertEqual(translations.lngettext.__name__, '_lngettext')
+        self.assertEqual(translations.ungettext.__name__, '_ungettext')
 
     def test_get_translation_object_python2_api_true(self):
         '''Smoketest that setting python2_api true yields the python2 functions'''
@@ -126,12 +125,12 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
                     '%s/data/locale-old' % os.path.dirname(__file__)], codeset='utf-8',
                 python2_api=True)
         translations.input_charset = 'utf-8'
-        tools.eq_(translations.gettext.__name__, '_gettext')
-        tools.eq_(translations.lgettext.__name__, '_lgettext')
-        tools.eq_(translations.ugettext.__name__, '_ugettext')
-        tools.eq_(translations.ngettext.__name__, '_ngettext')
-        tools.eq_(translations.lngettext.__name__, '_lngettext')
-        tools.eq_(translations.ungettext.__name__, '_ungettext')
+        self.assertEqual(translations.gettext.__name__, '_gettext')
+        self.assertEqual(translations.lgettext.__name__, '_lgettext')
+        self.assertEqual(translations.ugettext.__name__, '_ugettext')
+        self.assertEqual(translations.ngettext.__name__, '_ngettext')
+        self.assertEqual(translations.lngettext.__name__, '_lngettext')
+        self.assertEqual(translations.ungettext.__name__, '_ungettext')
 
     def test_get_translation_object_python2_api_false(self):
         '''Smoketest that setting python2_api false yields the python3 functions'''
@@ -141,23 +140,23 @@ class TestI18N_UTF8(unittest.TestCase, base_classes.UnicodeTestData):
                     '%s/data/locale-old' % os.path.dirname(__file__)], codeset='utf-8',
                 python2_api=False)
         translations.input_charset = 'utf-8'
-        tools.eq_(translations.gettext.__name__, '_ugettext')
-        tools.eq_(translations.lgettext.__name__, '_lgettext')
-        tools.eq_(translations.ngettext.__name__, '_ungettext')
-        tools.eq_(translations.lngettext.__name__, '_lngettext')
+        self.assertEqual(translations.gettext.__name__, '_ugettext')
+        self.assertEqual(translations.lgettext.__name__, '_lgettext')
+        self.assertEqual(translations.ngettext.__name__, '_ungettext')
+        self.assertEqual(translations.lngettext.__name__, '_lngettext')
 
-        tools.assert_raises(AttributeError, translations.ugettext, 'message')
-        tools.assert_raises(AttributeError, translations.ungettext, 'message1', 'message2')
+        self.assertRaises(AttributeError, translations.ugettext, 'message')
+        self.assertRaises(AttributeError, translations.ungettext, 'message1', 'message2')
 
     def test_dummy_translation(self):
         '''Test that we can create a DummyTranslation object
         '''
-        tools.assert_true(isinstance(i18n.DummyTranslations(), i18n.DummyTranslations))
+        self.assertTrue(isinstance(i18n.DummyTranslations(), i18n.DummyTranslations))
 
 # Note: Using nose's generator tests for this so we can't subclass
 # unittest.TestCase
-class TestDummyTranslations(base_classes.UnicodeTestData):
-    def __init__(self):
+class TestDummyTranslations(unittest.TestCase, base_classes.UnicodeTestData):
+    def setUp(self):
         self.test_data = {'bytes': (( # First set is with default charset (utf8)
                 (self.u_ascii, self.b_ascii),
                 (self.u_spanish, self.utf8_spanish),
@@ -214,14 +213,12 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
                 (self.utf8_japanese, self.u_mangled_japanese_utf8_as_ascii), # String mangled but no exception
                 ),
             )
-    }
-
-    def setUp(self):
+        }
         self.translations = i18n.DummyTranslations()
 
     def check_gettext(self, message, value, charset=None):
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.gettext(message), value,
+        self.assertEqual(self.translations.gettext(message), value,
                 msg='gettext(%s): trans: %s != val: %s (charset=%s)'
                 % (repr(message), repr(self.translations.gettext(message)),
                     repr(value), charset))
@@ -230,7 +227,7 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
             locale='en_US.UTF-8'):
         os.environ['LC_ALL'] = locale
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.lgettext(message), value,
+        self.assertEqual(self.translations.lgettext(message), value,
                 msg='lgettext(%s): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lgettext(message)),
                     repr(value), charset, locale))
@@ -240,34 +237,34 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
     def check_ugettext(self, message, value, charset='utf-8'):
         '''ugettext method with default values'''
         self.translations.input_charset = charset
-        tools.eq_(self.translations.ugettext(message), value,
+        self.assertEqual(self.translations.ugettext(message), value,
                 msg='ugettext(%s): trans: %s != val: %s (charset=%s)'
                 % (repr(message), repr(self.translations.ugettext(message)),
                     repr(value), charset))
 
     def check_ngettext(self, message, value, charset=None):
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.ngettext(message, 'blank', 1), value)
-        tools.eq_(self.translations.ngettext('blank', message, 2), value)
-        tools.assert_not_equal(self.translations.ngettext(message, 'blank', 2), value)
-        tools.assert_not_equal(self.translations.ngettext('blank', message, 1), value)
+        self.assertEqual(self.translations.ngettext(message, 'blank', 1), value)
+        self.assertEqual(self.translations.ngettext('blank', message, 2), value)
+        self.assertNotEqual(self.translations.ngettext(message, 'blank', 2), value)
+        self.assertNotEqual(self.translations.ngettext('blank', message, 1), value)
 
     def check_lngettext(self, message, value, charset=None, locale='en_US.UTF-8'):
         os.environ['LC_ALL'] = locale
         self.translations.set_output_charset(charset)
-        tools.eq_(self.translations.lngettext(message, 'blank', 1), value,
+        self.assertEqual(self.translations.lngettext(message, 'blank', 1), value,
                 msg='lngettext(%s, "blank", 1): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext(message,
                     'blank', 1)), repr(value), charset, locale))
-        tools.eq_(self.translations.lngettext('blank', message, 2), value,
+        self.assertEqual(self.translations.lngettext('blank', message, 2), value,
                 msg='lngettext("blank", %s, 2): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext('blank',
                     message, 2)), repr(value), charset, locale))
-        tools.assert_not_equal(self.translations.lngettext(message, 'blank', 2), value,
+        self.assertNotEqual(self.translations.lngettext(message, 'blank', 2), value,
                 msg='lngettext(%s, "blank", 2): trans: %s, val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext(message,
                     'blank', 2)), repr(value), charset, locale))
-        tools.assert_not_equal(self.translations.lngettext('blank', message, 1), value,
+        self.assertNotEqual(self.translations.lngettext('blank', message, 1), value,
                 msg='lngettext("blank", %s, 1): trans: %s != val: %s (charset=%s, locale=%s)'
                 % (repr(message), repr(self.translations.lngettext('blank',
                     message, 1)), repr(value), charset, locale))
@@ -276,10 +273,10 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
     # tearDown each time check_* is run.
     def check_ungettext(self, message, value, charset='utf-8'):
         self.translations.input_charset = charset
-        tools.eq_(self.translations.ungettext(message, 'blank', 1), value)
-        tools.eq_(self.translations.ungettext('blank', message, 2), value)
-        tools.assert_not_equal(self.translations.ungettext(message, 'blank', 2), value)
-        tools.assert_not_equal(self.translations.ungettext('blank', message, 1), value)
+        self.assertEqual(self.translations.ungettext(message, 'blank', 1), value)
+        self.assertEqual(self.translations.ungettext('blank', message, 2), value)
+        self.assertNotEqual(self.translations.ungettext(message, 'blank', 2), value)
+        self.assertNotEqual(self.translations.ungettext('blank', message, 1), value)
 
     def test_gettext(self):
         '''gettext method with default values'''
@@ -370,12 +367,12 @@ class TestDummyTranslations(base_classes.UnicodeTestData):
             yield self.check_ungettext, message, value, 'ascii'
 
     def test_nonbasestring(self):
-        tools.eq_(self.translations.gettext(dict(hi='there')), self.b_empty_string)
-        tools.eq_(self.translations.ngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
-        tools.eq_(self.translations.lgettext(dict(hi='there')), self.b_empty_string)
-        tools.eq_(self.translations.lngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
-        tools.eq_(self.translations.ugettext(dict(hi='there')), self.u_empty_string)
-        tools.eq_(self.translations.ungettext(dict(hi='there'), dict(hi='two'), 1), self.u_empty_string)
+        self.assertEqual(self.translations.gettext(dict(hi='there')), self.b_empty_string)
+        self.assertEqual(self.translations.ngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
+        self.assertEqual(self.translations.lgettext(dict(hi='there')), self.b_empty_string)
+        self.assertEqual(self.translations.lngettext(dict(hi='there'), dict(hi='two'), 1), self.b_empty_string)
+        self.assertEqual(self.translations.ugettext(dict(hi='there')), self.u_empty_string)
+        self.assertEqual(self.translations.ungettext(dict(hi='there'), dict(hi='two'), 1), self.u_empty_string)
 
 
 class TestI18N_Latin1(unittest.TestCase, base_classes.UnicodeTestData):
@@ -401,12 +398,12 @@ class TestI18N_Latin1(unittest.TestCase, base_classes.UnicodeTestData):
                 ['%s/data/locale/' % os.path.dirname(__file__)],
                 use_unicode=False)
 
-        tools.eq_(b_(self.utf8_spanish), self.utf8_spanish)
-        tools.eq_(b_(self.u_spanish), self.latin1_spanish)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
-        tools.eq_(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 1), self.latin1_limao)
-        tools.eq_(bN_(self.u_limao, self.u_limoes, 2), self.latin1_limoes)
+        self.assertEqual(b_(self.utf8_spanish), self.utf8_spanish)
+        self.assertEqual(b_(self.u_spanish), self.latin1_spanish)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_limao)
+        self.assertEqual(bN_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_limoes)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 1), self.latin1_limao)
+        self.assertEqual(bN_(self.u_limao, self.u_limoes, 2), self.latin1_limoes)
 
 
 class TestNewGNUTranslationsNoMatch(TestDummyTranslations):
@@ -448,104 +445,104 @@ class TestNewGNURealTranslations_UTF8(unittest.TestCase, base_classes.UnicodeTes
 
     def test_gettext(self):
         _ = self.translations.gettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_ngettext(self):
         _ = self.translations.ngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
 
     def test_ugettext(self):
         _ = self.translations.ugettext
-        tools.eq_(_(self.utf8_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.u_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.u_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.u_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.u_ja_kuratomi)
         # This is not translated to utf8_yes_in_fallback because this test is
         # without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.u_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.u_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.u_not_in_catalog)
 
     def test_ungettext(self):
         _ = self.translations.ungettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
 
 
 class TestNewGNURealTranslations_Latin1(TestNewGNURealTranslations_UTF8):
@@ -568,43 +565,43 @@ class TestNewGNURealTranslations_Latin1(TestNewGNURealTranslations_UTF8):
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
         # Neither of the following two tests encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
         #
         # This is not translated to latin1_yes_in_fallback because this test
         # is without the fallback message catalog
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.latin1_ja_kuratomi)
         # This is not translated to latin1_yes_in_fallback because this test
         # is without the fallback message catalog
-        tools.eq_(_(self.u_in_fallback), self.latin1_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.u_in_fallback), self.latin1_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
 
         # This unfortunately does not encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
 
 
 class TestFallbackNewGNUTranslationsNoMatch(TestDummyTranslations):
@@ -650,90 +647,90 @@ class TestFallbackNewGNURealTranslations_UTF8(unittest.TestCase, base_classes.Un
 
     def test_gettext(self):
         _ = self.translations.gettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_ngettext(self):
         _ = self.translations.ngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.utf8_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.utf8_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.utf8_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.utf8_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.utf8_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.utf8_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.utf8_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.utf8_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
 
     def test_ugettext(self):
         _ = self.translations.ugettext
-        tools.eq_(_(self.utf8_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.u_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.u_yes_in_fallback)
-        tools.eq_(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.u_yes_in_fallback)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.u_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.u_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.u_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.u_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.u_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.u_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.u_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.u_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.u_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.u_not_in_catalog)
 
     def test_ungettext(self):
         _ = self.translations.ungettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.u_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.u_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.u_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.u_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.u_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.u_lemons)
 
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.u_not_in_catalog)
 
 
 class TestFallbackNewGNURealTranslations_Latin1(TestFallbackNewGNURealTranslations_UTF8):
@@ -758,38 +755,38 @@ class TestFallbackNewGNURealTranslations_Latin1(TestFallbackNewGNURealTranslatio
 
     def test_lgettext(self):
         _ = self.translations.lgettext
-        tools.eq_(_(self.utf8_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
-        tools.eq_(_(self.utf8_in_fallback), self.latin1_yes_in_fallback)
+        self.assertEqual(_(self.utf8_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.utf8_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.utf8_in_fallback), self.latin1_yes_in_fallback)
         # This unfortunately does not encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
-        tools.eq_(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog), self.utf8_not_in_catalog)
 
-        tools.eq_(_(self.u_kitchen), self.latin1_pt_kitchen)
-        tools.eq_(_(self.u_ja_kuratomi), self.latin1_kuratomi)
-        tools.eq_(_(self.u_kuratomi), self.latin1_ja_kuratomi)
-        tools.eq_(_(self.u_in_fallback), self.latin1_yes_in_fallback)
-        tools.eq_(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.u_kitchen), self.latin1_pt_kitchen)
+        self.assertEqual(_(self.u_ja_kuratomi), self.latin1_kuratomi)
+        self.assertEqual(_(self.u_kuratomi), self.latin1_ja_kuratomi)
+        self.assertEqual(_(self.u_in_fallback), self.latin1_yes_in_fallback)
+        self.assertEqual(_(self.u_not_in_catalog), self.latin1_not_in_catalog)
 
     def test_lngettext(self):
         _ = self.translations.lngettext
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
-        tools.eq_(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 1), self.latin1_lemon)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 1), self.latin1_limao)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 1), self.latin1_lemon)
 
-        tools.eq_(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
-        tools.eq_(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
-        tools.eq_(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.utf8_lemon, self.utf8_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.utf8_limao, self.utf8_limoes, 2), self.latin1_lemons)
+        self.assertEqual(_(self.u_lemon, self.u_lemons, 2), self.latin1_limoes)
+        self.assertEqual(_(self.u_limao, self.u_limoes, 2), self.latin1_lemons)
 
         # This unfortunately does not encode to proper latin-1 because:
         # any byte is valid in latin-1 so there's no way to know that what
         # we're given in the string is really utf-8
-        tools.eq_(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
-        tools.eq_(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
+        self.assertEqual(_(self.utf8_not_in_catalog, 'throwaway', 1), self.utf8_not_in_catalog)
+        self.assertEqual(_(self.u_not_in_catalog, 'throwaway', 1), self.latin1_not_in_catalog)
 
 
 class TestFallback(unittest.TestCase, base_classes.UnicodeTestData):
@@ -820,21 +817,21 @@ class TestFallback(unittest.TestCase, base_classes.UnicodeTestData):
 
     def test_invalid_fallback_no_raise(self):
         '''Test when we have an invalid fallback that it does not raise.'''
-        tools.eq_(self.gtranslations.gettext(self.u_spanish), self.utf8_spanish)
-        tools.eq_(self.gtranslations.ugettext(self.u_spanish), self.u_spanish)
-        tools.eq_(self.gtranslations.lgettext(self.u_spanish), self.latin1_spanish)
+        self.assertEqual(self.gtranslations.gettext(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(self.gtranslations.ugettext(self.u_spanish), self.u_spanish)
+        self.assertEqual(self.gtranslations.lgettext(self.u_spanish), self.latin1_spanish)
 
-        tools.eq_(self.gtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
-        tools.eq_(self.gtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
-        tools.eq_(self.gtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
+        self.assertEqual(self.gtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
+        self.assertEqual(self.gtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
+        self.assertEqual(self.gtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
 
-        tools.eq_(self.dtranslations.gettext(self.u_spanish), self.utf8_spanish)
-        tools.eq_(self.dtranslations.ugettext(self.u_spanish), self.u_spanish)
-        tools.eq_(self.dtranslations.lgettext(self.u_spanish), self.latin1_spanish)
+        self.assertEqual(self.dtranslations.gettext(self.u_spanish), self.utf8_spanish)
+        self.assertEqual(self.dtranslations.ugettext(self.u_spanish), self.u_spanish)
+        self.assertEqual(self.dtranslations.lgettext(self.u_spanish), self.latin1_spanish)
 
-        tools.eq_(self.dtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
-        tools.eq_(self.dtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
-        tools.eq_(self.dtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
+        self.assertEqual(self.dtranslations.ngettext(self.u_spanish, 'cde', 1), self.utf8_spanish)
+        self.assertEqual(self.dtranslations.ungettext(self.u_spanish, 'cde', 1), self.u_spanish)
+        self.assertEqual(self.dtranslations.lngettext(self.u_spanish, 'cde', 1), self.latin1_spanish)
 
 
 class TestDefaultLocaleDir(unittest.TestCase, base_classes.UnicodeTestData):
@@ -863,16 +860,16 @@ class TestDefaultLocaleDir(unittest.TestCase, base_classes.UnicodeTestData):
 
     def test_gettext(self):
         _ = self.translations.gettext
-        tools.eq_(_(self.utf8_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.utf8_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.utf8_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.utf8_ja_kuratomi), self.utf8_kuratomi)
         # Returns msgid because the string is in a fallback catalog which we
         # haven't setup
-        tools.eq_(_(self.utf8_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.utf8_in_fallback), self.utf8_in_fallback)
 
-        tools.eq_(_(self.u_kitchen), self.utf8_pt_kitchen)
-        tools.eq_(_(self.u_kuratomi), self.utf8_ja_kuratomi)
-        tools.eq_(_(self.u_ja_kuratomi), self.utf8_kuratomi)
+        self.assertEqual(_(self.u_kitchen), self.utf8_pt_kitchen)
+        self.assertEqual(_(self.u_kuratomi), self.utf8_ja_kuratomi)
+        self.assertEqual(_(self.u_ja_kuratomi), self.utf8_kuratomi)
         # Returns msgid because the string is in a fallback catalog which we
         # haven't setup
-        tools.eq_(_(self.u_in_fallback), self.utf8_in_fallback)
+        self.assertEqual(_(self.u_in_fallback), self.utf8_in_fallback)

--- a/kitchen3/tests/test_iterutils.py
+++ b/kitchen3/tests/test_iterutils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 from kitchen import iterutils
 
@@ -31,32 +30,32 @@ class TestIterutils(unittest.TestCase):
 
     def test_isiterable(self):
         for item in self.iterable_data:
-            tools.ok_(iterutils.isiterable(item) == True)
+            self.assertTrue(iterutils.isiterable(item) == True)
 
         for item in self.non_iterable_data:
-            tools.ok_(iterutils.isiterable(item) == False)
+            self.assertTrue(iterutils.isiterable(item) == False)
 
         # strings
-        tools.ok_(iterutils.isiterable(b'a', include_string=True) == True)
-        tools.ok_(iterutils.isiterable(b'a', include_string=False) == False)
-        tools.ok_(iterutils.isiterable(b'a') == False)
-        tools.ok_(iterutils.isiterable('a', include_string=True) == True)
-        tools.ok_(iterutils.isiterable('a', include_string=False) == False)
-        tools.ok_(iterutils.isiterable('a') == False)
+        self.assertTrue(iterutils.isiterable(b'a', include_string=True) == True)
+        self.assertTrue(iterutils.isiterable(b'a', include_string=False) == False)
+        self.assertTrue(iterutils.isiterable(b'a') == False)
+        self.assertTrue(iterutils.isiterable('a', include_string=True) == True)
+        self.assertTrue(iterutils.isiterable('a', include_string=False) == False)
+        self.assertTrue(iterutils.isiterable('a') == False)
 
     def test_iterate(self):
         iterutils.iterate(None)
         for item in self.non_iterable_data:
-            tools.ok_(list(iterutils.iterate(item)) == [item])
+            self.assertTrue(list(iterutils.iterate(item)) == [item])
 
         for item in self.iterable_data[:-1]:
-            tools.ok_(list(iterutils.iterate(item)) == list(item))
+            self.assertTrue(list(iterutils.iterate(item)) == list(item))
 
         # iter() is exhausted after use so we have to test separately
-        tools.ok_(list(iterutils.iterate(iter([1, 2, 3]))) == [1, 2, 3])
+        self.assertTrue(list(iterutils.iterate(iter([1, 2, 3]))) == [1, 2, 3])
 
         # strings
-        tools.ok_(list(iterutils.iterate(b'abc')) == [b'abc'])
-        tools.eq_(list(iterutils.iterate(b'abc', include_string=True)), [ord(b'a'), ord(b'b'), ord(b'c')])
-        tools.ok_(list(iterutils.iterate('abc')) == ['abc'])
-        tools.ok_(list(iterutils.iterate('abc', include_string=True)) == ['a', 'b', 'c'])
+        self.assertTrue(list(iterutils.iterate(b'abc')) == [b'abc'])
+        self.assertEqual(list(iterutils.iterate(b'abc', include_string=True)), [ord(b'a'), ord(b'b'), ord(b'c')])
+        self.assertTrue(list(iterutils.iterate('abc')) == ['abc'])
+        self.assertTrue(list(iterutils.iterate('abc', include_string=True)) == ['a', 'b', 'c'])

--- a/kitchen3/tests/test_pycompat.py
+++ b/kitchen3/tests/test_pycompat.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 class TestUsableModules(unittest.TestCase):
     def test_subprocess(self):
@@ -10,11 +9,11 @@ class TestUsableModules(unittest.TestCase):
         try:
             from kitchen.pycompat24.subprocess import Popen
         except ImportError:
-            tools.ok_(False, 'Unable to import pycompat24.subprocess as a module')
+            self.assertTrue(False, 'Unable to import pycompat24.subprocess as a module')
         try:
             from kitchen.pycompat27.subprocess import Popen
         except ImportError:
-            tools.ok_(False, 'Unable to import pycompat27.subprocess as a module')
+            self.assertTrue(False, 'Unable to import pycompat27.subprocess as a module')
 
     def test_base64(self):
         '''Test that importing base64 as a module works
@@ -22,4 +21,4 @@ class TestUsableModules(unittest.TestCase):
         try:
             from kitchen.pycompat24.base64 import b64encode
         except ImportError:
-            tools.ok_(False, 'Unable to import pycompat24.base64 as a module')
+            self.assertTrue(False, 'Unable to import pycompat24.base64 as a module')

--- a/kitchen3/tests/test_text_display.py
+++ b/kitchen3/tests/test_text_display.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 from kitchen.text.exceptions import ControlCharError
 
@@ -14,19 +13,19 @@ class TestDisplay(base_classes.UnicodeTestData, unittest.TestCase):
     def test_internal_interval_bisearch(self):
         '''Test that we can find things in an interval table'''
         table = ((0, 3), (5, 7), (9, 10))
-        tools.assert_true(display._interval_bisearch(0, table))
-        tools.assert_true(display._interval_bisearch(1, table))
-        tools.assert_true(display._interval_bisearch(2, table))
-        tools.assert_true(display._interval_bisearch(3, table))
-        tools.assert_true(display._interval_bisearch(5, table))
-        tools.assert_true(display._interval_bisearch(6, table))
-        tools.assert_true(display._interval_bisearch(7, table))
-        tools.assert_true(display._interval_bisearch(9, table))
-        tools.assert_true(display._interval_bisearch(10, table))
-        tools.assert_false(display._interval_bisearch(-1, table))
-        tools.assert_false(display._interval_bisearch(4, table))
-        tools.assert_false(display._interval_bisearch(8, table))
-        tools.assert_false(display._interval_bisearch(11, table))
+        self.assertTrue(display._interval_bisearch(0, table))
+        self.assertTrue(display._interval_bisearch(1, table))
+        self.assertTrue(display._interval_bisearch(2, table))
+        self.assertTrue(display._interval_bisearch(3, table))
+        self.assertTrue(display._interval_bisearch(5, table))
+        self.assertTrue(display._interval_bisearch(6, table))
+        self.assertTrue(display._interval_bisearch(7, table))
+        self.assertTrue(display._interval_bisearch(9, table))
+        self.assertTrue(display._interval_bisearch(10, table))
+        self.assertFalse(display._interval_bisearch(-1, table))
+        self.assertFalse(display._interval_bisearch(4, table))
+        self.assertFalse(display._interval_bisearch(8, table))
+        self.assertFalse(display._interval_bisearch(11, table))
 
     def test_internal_generate_combining_table(self):
         '''Test that the combining table we generate is equal to or a subset of what's in the current table
@@ -40,27 +39,27 @@ class TestDisplay(base_classes.UnicodeTestData, unittest.TestCase):
         new_table = display._generate_combining_table()
         for interval in new_table:
             if interval[0] == interval[1]:
-                tools.assert_true(display._interval_bisearch(interval[0], old_table))
+                self.assertTrue(display._interval_bisearch(interval[0], old_table))
             else:
                 for codepoint in range(interval[0], interval[1] + 1):
-                    tools.assert_true(display._interval_bisearch(interval[0], old_table))
+                    self.assertTrue(display._interval_bisearch(interval[0], old_table))
 
     def test_internal_ucp_width(self):
         '''Test that ucp_width returns proper width for characters'''
         for codepoint in range(0, 0xFFFFF + 1):
             if codepoint < 32 or (codepoint < 0xa0 and codepoint >= 0x7f):
                 # With strict on, we should raise an error
-                tools.assert_raises(ControlCharError, display._ucp_width, codepoint, 'strict')
+                self.assertRaises(ControlCharError, display._ucp_width, codepoint, 'strict')
 
                 if codepoint in (0x08, 0x1b, 0x7f, 0x94):
                     # Backspace, delete, clear delete remove one char
-                    tools.eq_(display._ucp_width(codepoint), -1)
+                    self.assertEqual(display._ucp_width(codepoint), -1)
                 else:
                     # Everything else returns 0
-                    tools.eq_(display._ucp_width(codepoint), 0)
+                    self.assertEqual(display._ucp_width(codepoint), 0)
             elif display._interval_bisearch(codepoint, display._COMBINING):
                 # Combining character
-                tools.eq_(display._ucp_width(codepoint), 0)
+                self.assertEqual(display._ucp_width(codepoint), 0)
             elif (codepoint >= 0x1100 and
                     (codepoint <= 0x115f or                     # Hangul Jamo init. consonants
                         codepoint == 0x2329 or codepoint == 0x232a or
@@ -74,87 +73,87 @@ class TestDisplay(base_classes.UnicodeTestData, unittest.TestCase):
                         (codepoint >= 0xffe0 and codepoint <= 0xffe6) or
                         (codepoint >= 0x20000 and codepoint <= 0x2fffd) or
                         (codepoint >= 0x30000 and codepoint <= 0x3fffd))):
-                tools.eq_(display._ucp_width(codepoint), 2)
+                self.assertEqual(display._ucp_width(codepoint), 2)
             else:
-                tools.eq_(display._ucp_width(codepoint), 1)
+                self.assertEqual(display._ucp_width(codepoint), 1)
 
     def test_textual_width(self):
         '''Test that we find the proper number of spaces that a utf8 string will consume'''
-        tools.eq_(display.textual_width(self.u_japanese), 31)
-        tools.eq_(display.textual_width(self.u_spanish), 50)
-        tools.eq_(display.textual_width(self.u_mixed), 23)
+        self.assertEqual(display.textual_width(self.u_japanese), 31)
+        self.assertEqual(display.textual_width(self.u_spanish), 50)
+        self.assertEqual(display.textual_width(self.u_mixed), 23)
 
     def test_textual_width_chop(self):
         '''utf8_width_chop with byte strings'''
-        tools.eq_(display.textual_width_chop(self.u_mixed, 1000), self.u_mixed)
-        tools.eq_(display.textual_width_chop(self.u_mixed, 23), self.u_mixed)
-        tools.eq_(display.textual_width_chop(self.u_mixed, 22), self.u_mixed[:-1])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:-4])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 1), '')
-        tools.eq_(display.textual_width_chop(self.u_mixed, 2), self.u_mixed[0])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 3), self.u_mixed[:2])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 4), self.u_mixed[:3])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 5), self.u_mixed[:4])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 6), self.u_mixed[:5])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 7), self.u_mixed[:5])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 8), self.u_mixed[:6])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 9), self.u_mixed[:7])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 10), self.u_mixed[:8])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 11), self.u_mixed[:9])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 12), self.u_mixed[:10])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 13), self.u_mixed[:10])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 14), self.u_mixed[:11])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 15), self.u_mixed[:12])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 16), self.u_mixed[:13])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 17), self.u_mixed[:14])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 18), self.u_mixed[:15])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:15])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 20), self.u_mixed[:16])
-        tools.eq_(display.textual_width_chop(self.u_mixed, 21), self.u_mixed[:17])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 1000), self.u_mixed)
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 23), self.u_mixed)
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 22), self.u_mixed[:-1])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:-4])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 1), '')
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 2), self.u_mixed[0])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 3), self.u_mixed[:2])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 4), self.u_mixed[:3])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 5), self.u_mixed[:4])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 6), self.u_mixed[:5])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 7), self.u_mixed[:5])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 8), self.u_mixed[:6])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 9), self.u_mixed[:7])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 10), self.u_mixed[:8])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 11), self.u_mixed[:9])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 12), self.u_mixed[:10])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 13), self.u_mixed[:10])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 14), self.u_mixed[:11])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 15), self.u_mixed[:12])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 16), self.u_mixed[:13])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 17), self.u_mixed[:14])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 18), self.u_mixed[:15])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 19), self.u_mixed[:15])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 20), self.u_mixed[:16])
+        self.assertEqual(display.textual_width_chop(self.u_mixed, 21), self.u_mixed[:17])
 
     def test_textual_width_fill(self):
         '''Pad a utf8 string'''
-        tools.eq_(display.textual_width_fill(self.u_mixed, 1), self.u_mixed)
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25), self.u_mixed + '  ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, left=False), '  ' + self.u_mixed)
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + '       ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + '       ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + '       ')
-        tools.eq_(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + '       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 1), self.u_mixed)
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25), self.u_mixed + '  ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, left=False), '  ' + self.u_mixed)
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + '       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + '       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18), self.u_mixed[:-4] + '       ')
+        self.assertEqual(display.textual_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.u_spanish), self.u_spanish + self.u_mixed[:-4] + self.u_spanish + '       ')
 
     def test_internal_textual_width_le(self):
         test_data = ''.join([self.u_mixed, self.u_spanish])
         tw = display.textual_width(test_data)
-        tools.eq_(display._textual_width_le(68, self.u_mixed, self.u_spanish), (tw <= 68))
-        tools.eq_(display._textual_width_le(69, self.u_mixed, self.u_spanish), (tw <= 69))
-        tools.eq_(display._textual_width_le(137, self.u_mixed, self.u_spanish), (tw <= 137))
-        tools.eq_(display._textual_width_le(138, self.u_mixed, self.u_spanish), (tw <= 138))
-        tools.eq_(display._textual_width_le(78, self.u_mixed, self.u_spanish), (tw <= 78))
-        tools.eq_(display._textual_width_le(79, self.u_mixed, self.u_spanish), (tw <= 79))
+        self.assertEqual(display._textual_width_le(68, self.u_mixed, self.u_spanish), (tw <= 68))
+        self.assertEqual(display._textual_width_le(69, self.u_mixed, self.u_spanish), (tw <= 69))
+        self.assertEqual(display._textual_width_le(137, self.u_mixed, self.u_spanish), (tw <= 137))
+        self.assertEqual(display._textual_width_le(138, self.u_mixed, self.u_spanish), (tw <= 138))
+        self.assertEqual(display._textual_width_le(78, self.u_mixed, self.u_spanish), (tw <= 78))
+        self.assertEqual(display._textual_width_le(79, self.u_mixed, self.u_spanish), (tw <= 79))
 
     def test_wrap(self):
         '''Test that text wrapping works'''
-        tools.eq_(display.wrap(self.u_mixed), [self.u_mixed])
-        tools.eq_(display.wrap(self.u_paragraph), self.u_paragraph_out)
-        tools.eq_(display.wrap(self.utf8_paragraph), self.u_paragraph_out)
-        tools.eq_(display.wrap(self.u_mixed_para), self.u_mixed_para_out)
-        tools.eq_(display.wrap(self.u_mixed_para, width=57,
+        self.assertEqual(display.wrap(self.u_mixed), [self.u_mixed])
+        self.assertEqual(display.wrap(self.u_paragraph), self.u_paragraph_out)
+        self.assertEqual(display.wrap(self.utf8_paragraph), self.u_paragraph_out)
+        self.assertEqual(display.wrap(self.u_mixed_para), self.u_mixed_para_out)
+        self.assertEqual(display.wrap(self.u_mixed_para, width=57,
             initial_indent='    ', subsequent_indent='----'),
             self.u_mixed_para_57_initial_subsequent_out)
 
     def test_fill(self):
-        tools.eq_(display.fill(self.u_paragraph), '\n'.join(self.u_paragraph_out))
-        tools.eq_(display.fill(self.utf8_paragraph), '\n'.join(self.u_paragraph_out))
-        tools.eq_(display.fill(self.u_mixed_para), '\n'.join(self.u_mixed_para_out))
-        tools.eq_(display.fill(self.u_mixed_para, width=57,
+        self.assertEqual(display.fill(self.u_paragraph), '\n'.join(self.u_paragraph_out))
+        self.assertEqual(display.fill(self.utf8_paragraph), '\n'.join(self.u_paragraph_out))
+        self.assertEqual(display.fill(self.u_mixed_para), '\n'.join(self.u_mixed_para_out))
+        self.assertEqual(display.fill(self.u_mixed_para, width=57,
             initial_indent='    ', subsequent_indent='----'),
             '\n'.join(self.u_mixed_para_57_initial_subsequent_out))
 
     def test_byte_string_textual_width_fill(self):
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 1), self.utf8_mixed)
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25), self.utf8_mixed + b'  ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, left=False), b'  ' + self.utf8_mixed)
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + b'       ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + b'       ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + b'       ')
-        tools.eq_(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + b'       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 1), self.utf8_mixed)
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25), self.utf8_mixed + b'  ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, left=False), b'  ' + self.utf8_mixed)
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + b'       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + b'       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18), self.u_mixed[:-4].encode('utf8') + b'       ')
+        self.assertEqual(display.byte_string_textual_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish), self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + b'       ')

--- a/kitchen3/tests/test_text_misc.py
+++ b/kitchen3/tests/test_text_misc.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
-from nose.plugins.skip import SkipTest
 
 try:
     import chardet
@@ -18,136 +16,136 @@ import base_classes
 class TestTextMisc(unittest.TestCase, base_classes.UnicodeTestData):
     def test_guess_encoding_no_chardet(self):
         # Test that unicode strings are not allowed
-        tools.assert_raises(TypeError, misc.guess_encoding, self.u_spanish)
+        self.assertRaises(TypeError, misc.guess_encoding, self.u_spanish)
 
-        tools.ok_(misc.guess_encoding(self.utf8_spanish, disable_chardet=True) == 'utf-8')
-        tools.ok_(misc.guess_encoding(self.latin1_spanish, disable_chardet=True) == 'latin-1')
-        tools.ok_(misc.guess_encoding(self.utf8_japanese, disable_chardet=True) == 'utf-8')
-        tools.ok_(misc.guess_encoding(self.euc_jp_japanese, disable_chardet=True) == 'latin-1')
+        self.assertTrue(misc.guess_encoding(self.utf8_spanish, disable_chardet=True) == 'utf-8')
+        self.assertTrue(misc.guess_encoding(self.latin1_spanish, disable_chardet=True) == 'latin-1')
+        self.assertTrue(misc.guess_encoding(self.utf8_japanese, disable_chardet=True) == 'utf-8')
+        self.assertTrue(misc.guess_encoding(self.euc_jp_japanese, disable_chardet=True) == 'latin-1')
 
     def test_guess_encoding_with_chardet(self):
         # We go this slightly roundabout way because multiple encodings can
         # output the same byte sequence.  What we're really interested in is
         # if we can get the original unicode string without knowing the
         # converters beforehand
-        tools.ok_(to_unicode(self.utf8_spanish,
+        self.assertTrue(to_unicode(self.utf8_spanish,
             misc.guess_encoding(self.utf8_spanish)) == self.u_spanish)
-        tools.ok_(to_unicode(self.latin1_spanish,
+        self.assertTrue(to_unicode(self.latin1_spanish,
             misc.guess_encoding(self.latin1_spanish)) == self.u_spanish)
-        tools.ok_(to_unicode(self.utf8_japanese,
+        self.assertTrue(to_unicode(self.utf8_japanese,
             misc.guess_encoding(self.utf8_japanese)) == self.u_japanese)
 
     def test_guess_encoding_with_chardet_installed(self):
         if chardet:
-            tools.ok_(to_unicode(self.euc_jp_japanese,
+            self.assertTrue(to_unicode(self.euc_jp_japanese,
                 misc.guess_encoding(self.euc_jp_japanese)) == self.u_japanese)
         else:
-            raise SkipTest('chardet not installed, euc_jp will not be guessed correctly')
+            self.skipTest('chardet not installed, euc_jp will not be guessed correctly')
 
     def test_guess_encoding_with_chardet_uninstalled(self):
         if chardet:
-            raise SkipTest('chardet installed, euc_jp will not be mangled')
+            self.skipTest('chardet installed, euc_jp will not be mangled')
         else:
-            tools.ok_(to_unicode(self.euc_jp_japanese,
+            self.assertTrue(to_unicode(self.euc_jp_japanese,
                 misc.guess_encoding(self.euc_jp_japanese)) ==
                 self.u_mangled_euc_jp_as_latin1)
 
     def test_str_eq(self):
         # str vs str:
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.euc_jp_japanese) == True)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.utf8_japanese) == True)
-        tools.ok_(misc.str_eq(self.b_ascii, self.b_ascii) == True)
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.latin1_spanish) == False)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.euc_jp_japanese) == False)
-        tools.ok_(misc.str_eq(self.b_ascii, self.b_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.euc_jp_japanese) == True)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.utf8_japanese) == True)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.b_ascii) == True)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.latin1_spanish) == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.euc_jp_japanese) == False)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.b_ascii[:-2]) == False)
 
         # unicode vs unicode:
-        tools.ok_(misc.str_eq(self.u_japanese, self.u_japanese) == True)
-        tools.ok_(misc.str_eq(self.u_ascii, self.u_ascii) == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.u_spanish) == False)
-        tools.ok_(misc.str_eq(self.u_ascii, self.u_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.u_japanese) == True)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.u_ascii) == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.u_spanish) == False)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.u_ascii[:-2]) == False)
 
         # unicode vs str with default utf-8 conversion:
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese) == True)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii) == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.euc_jp_japanese) == False)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese) == True)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii) == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.euc_jp_japanese) == False)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii[:-2]) == False)
 
         # unicode vs str with explicit encodings:
-        tools.ok_(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='euc_jp') == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='utf8') == True)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii, encoding='latin1') == True)
-        tools.ok_(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='latin1') == False)
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.u_ascii, self.b_ascii[:-2], encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='euc_jp') == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='utf8') == True)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii, encoding='latin1') == True)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.euc_jp_japanese, encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.u_japanese, self.utf8_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.u_ascii, self.b_ascii[:-2], encoding='latin1') == False)
 
         # str vs unicode (reverse parameter order of unicode vs str)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese) == True)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii) == True)
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.u_japanese) == False)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii[:-2]) == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese) == True)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii) == True)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.u_japanese) == False)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii[:-2]) == False)
 
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='euc_jp') == True)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='utf8') == True)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii, encoding='latin1') == True)
-        tools.ok_(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='latin1') == False)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
-        tools.ok_(misc.str_eq(self.b_ascii, self.u_ascii[:-2], encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='euc_jp') == True)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='utf8') == True)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii, encoding='latin1') == True)
+        self.assertTrue(misc.str_eq(self.euc_jp_japanese, self.u_japanese, encoding='latin1') == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.utf8_japanese, self.u_japanese, encoding='euc_jp') == False)
+        self.assertTrue(misc.str_eq(self.b_ascii, self.u_ascii[:-2], encoding='latin1') == False)
 
 
     def test_process_control_chars(self):
-        tools.assert_raises(TypeError, misc.process_control_chars, b'byte string')
-        tools.assert_raises(ControlCharError, misc.process_control_chars,
+        self.assertRaises(TypeError, misc.process_control_chars, b'byte string')
+        self.assertRaises(ControlCharError, misc.process_control_chars,
                 *[self.u_ascii_chars], **{'strategy': 'strict'})
-        tools.ok_(misc.process_control_chars(self.u_ascii_chars,
+        self.assertTrue(misc.process_control_chars(self.u_ascii_chars,
             strategy='ignore') == self.u_ascii_no_ctrl)
-        tools.ok_(misc.process_control_chars(self.u_ascii_chars,
+        self.assertTrue(misc.process_control_chars(self.u_ascii_chars,
             strategy='replace') == self.u_ascii_ctrl_replace)
 
     def test_html_entities_unescape(self):
-        tools.assert_raises(TypeError, misc.html_entities_unescape, b'byte string')
-        tools.ok_(misc.html_entities_unescape(self.u_entity_escape) == self.u_entity)
-        tools.ok_(misc.html_entities_unescape('<tag>%s</tag>'
+        self.assertRaises(TypeError, misc.html_entities_unescape, b'byte string')
+        self.assertTrue(misc.html_entities_unescape(self.u_entity_escape) == self.u_entity)
+        self.assertTrue(misc.html_entities_unescape('<tag>%s</tag>'
             % self.u_entity_escape) == self.u_entity)
-        tools.ok_(misc.html_entities_unescape('a&#1234567890;b') == 'a&#1234567890;b')
-        tools.ok_(misc.html_entities_unescape('a&#xfffd;b') == 'a\ufffdb')
-        tools.ok_(misc.html_entities_unescape('a&#65533;b') == 'a\ufffdb')
+        self.assertTrue(misc.html_entities_unescape('a&#1234567890;b') == 'a&#1234567890;b')
+        self.assertTrue(misc.html_entities_unescape('a&#xfffd;b') == 'a\ufffdb')
+        self.assertTrue(misc.html_entities_unescape('a&#65533;b') == 'a\ufffdb')
 
     def test_byte_string_valid_xml(self):
-        tools.ok_(misc.byte_string_valid_xml('unicode string') == False)
+        self.assertTrue(misc.byte_string_valid_xml('unicode string') == False)
 
-        tools.ok_(misc.byte_string_valid_xml(self.utf8_japanese))
-        tools.ok_(misc.byte_string_valid_xml(self.euc_jp_japanese, 'euc_jp'))
+        self.assertTrue(misc.byte_string_valid_xml(self.utf8_japanese))
+        self.assertTrue(misc.byte_string_valid_xml(self.euc_jp_japanese, 'euc_jp'))
 
-        tools.ok_(misc.byte_string_valid_xml(self.utf8_japanese, 'euc_jp') == False)
-        tools.ok_(misc.byte_string_valid_xml(self.euc_jp_japanese, 'utf8') == False)
+        self.assertTrue(misc.byte_string_valid_xml(self.utf8_japanese, 'euc_jp') == False)
+        self.assertTrue(misc.byte_string_valid_xml(self.euc_jp_japanese, 'utf8') == False)
 
-        tools.ok_(misc.byte_string_valid_xml(self.utf8_ascii_chars) == False)
+        self.assertTrue(misc.byte_string_valid_xml(self.utf8_ascii_chars) == False)
 
     def test_byte_string_valid_encoding(self):
         '''Test that a byte sequence is validated'''
-        tools.ok_(misc.byte_string_valid_encoding(self.utf8_japanese) == True)
-        tools.ok_(misc.byte_string_valid_encoding(self.euc_jp_japanese, encoding='euc_jp') == True)
+        self.assertTrue(misc.byte_string_valid_encoding(self.utf8_japanese) == True)
+        self.assertTrue(misc.byte_string_valid_encoding(self.euc_jp_japanese, encoding='euc_jp') == True)
 
     def test_byte_string_invalid_encoding(self):
         '''Test that we return False with non-encoded chars'''
-        tools.ok_(misc.byte_string_valid_encoding(b'\xff') == False)
-        tools.ok_(misc.byte_string_valid_encoding(self.euc_jp_japanese) == False)
+        self.assertTrue(misc.byte_string_valid_encoding(b'\xff') == False)
+        self.assertTrue(misc.byte_string_valid_encoding(self.euc_jp_japanese) == False)
 
 class TestIsStringTypes(unittest.TestCase):
     def test_isbasestring(self):
-        tools.assert_true(misc.isbasestring(b'abc'))
-        tools.assert_true(misc.isbasestring('abc'))
-        tools.assert_false(misc.isbasestring(5))
+        self.assertTrue(misc.isbasestring(b'abc'))
+        self.assertTrue(misc.isbasestring('abc'))
+        self.assertFalse(misc.isbasestring(5))
 
     def test_isbytestring(self):
-        tools.assert_true(misc.isbytestring(b'abc'))
-        tools.assert_false(misc.isbytestring('abc'))
-        tools.assert_false(misc.isbytestring(5))
+        self.assertTrue(misc.isbytestring(b'abc'))
+        self.assertFalse(misc.isbytestring('abc'))
+        self.assertFalse(misc.isbytestring(5))
 
     def test_isunicodestring(self):
-        tools.assert_false(misc.isunicodestring(b'abc'))
-        tools.assert_true(misc.isunicodestring('abc'))
-        tools.assert_false(misc.isunicodestring(5))
+        self.assertFalse(misc.isunicodestring(b'abc'))
+        self.assertTrue(misc.isunicodestring('abc'))
+        self.assertFalse(misc.isunicodestring(5))

--- a/kitchen3/tests/test_text_utf8.py
+++ b/kitchen3/tests/test_text_utf8.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import unittest
-from nose import tools
 
 import warnings
 
@@ -19,9 +18,9 @@ class TestUTF8(base_classes.UnicodeTestData, unittest.TestCase):
 
     def test_utf8_width(self):
         '''Test that we find the proper number of spaces that a utf8 string will consume'''
-        tools.ok_(utf8.utf8_width(self.utf8_japanese) == 31)
-        tools.ok_(utf8.utf8_width(self.utf8_spanish) == 50)
-        tools.ok_(utf8.utf8_width(self.utf8_mixed) == 23)
+        self.assertTrue(utf8.utf8_width(self.utf8_japanese) == 31)
+        self.assertTrue(utf8.utf8_width(self.utf8_spanish) == 50)
+        self.assertTrue(utf8.utf8_width(self.utf8_mixed) == 23)
 
     def test_utf8_width_non_utf8(self):
         '''Test that we handle non-utf8 bytes in utf8_width without backtracing'''
@@ -35,58 +34,58 @@ class TestUTF8(base_classes.UnicodeTestData, unittest.TestCase):
         # El veloz murci�go salt�bre el perro perezoso.
         if len(str('\xe9la'.encode('latin1'), 'utf8', 'replace')) == 1:
             # Python < 2.7
-            tools.ok_(utf8.utf8_width(self.latin1_spanish) == 45)
+            self.assertTrue(utf8.utf8_width(self.latin1_spanish) == 45)
         else:
             # Python >= 2.7
-            tools.ok_(utf8.utf8_width(self.latin1_spanish) == 50)
+            self.assertTrue(utf8.utf8_width(self.latin1_spanish) == 50)
 
     def test_utf8_width_chop(self):
         '''utf8_width_chop with byte strings'''
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed) == (23, self.utf8_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 23) == (23, self.utf8_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 22) == (22, self.utf8_mixed[:-1]))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 19) == (18, self.u_mixed[:-4].encode('utf8')))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 2) == (2, self.u_mixed[0].encode('utf8')))
-        tools.ok_(utf8.utf8_width_chop(self.utf8_mixed, 1) == (0, b''))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed) == (23, self.utf8_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 23) == (23, self.utf8_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 22) == (22, self.utf8_mixed[:-1]))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 19) == (18, self.u_mixed[:-4].encode('utf8')))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 2) == (2, self.u_mixed[0].encode('utf8')))
+        self.assertTrue(utf8.utf8_width_chop(self.utf8_mixed, 1) == (0, b''))
 
     def test_utf8_width_chop_unicode(self):
         '''utf8_width_chop with unicode input'''
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed) == (23, self.u_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 23) == (23, self.u_mixed))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 22) == (22, self.u_mixed[:-1]))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 19) == (18, self.u_mixed[:-4]))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 2) == (2, self.u_mixed[0]))
-        tools.ok_(utf8.utf8_width_chop(self.u_mixed, 1), (0, ''))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed) == (23, self.u_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 23) == (23, self.u_mixed))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 22) == (22, self.u_mixed[:-1]))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 19) == (18, self.u_mixed[:-4]))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 2) == (2, self.u_mixed[0]))
+        self.assertTrue(utf8.utf8_width_chop(self.u_mixed, 1), (0, ''))
 
     def test_utf8_width_fill(self):
         '''Pad a utf8 string'''
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 1) == self.utf8_mixed)
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25) == self.utf8_mixed + b'  ')
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, left=False) == b'  ' + self.utf8_mixed)
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + b'       ')
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish) == self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + b'       ')
-        tools.ok_(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + b'       ')
-        tools.ok_(utf8.utf8_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.utf8_spanish) == self.u_spanish.encode('utf8') + self.u_mixed[:-4].encode('utf8') + self.u_spanish.encode('utf8') + b'       ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 1) == self.utf8_mixed)
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25) == self.utf8_mixed + b'  ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, left=False) == b'  ' + self.utf8_mixed)
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + b'       ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18, prefix=self.utf8_spanish, suffix=self.utf8_spanish) == self.utf8_spanish + self.u_mixed[:-4].encode('utf8') + self.utf8_spanish + b'       ')
+        self.assertTrue(utf8.utf8_width_fill(self.utf8_mixed, 25, chop=18) == self.u_mixed[:-4].encode('utf8') + b'       ')
+        self.assertTrue(utf8.utf8_width_fill(self.u_mixed, 25, chop=18, prefix=self.u_spanish, suffix=self.utf8_spanish) == self.u_spanish.encode('utf8') + self.u_mixed[:-4].encode('utf8') + self.u_spanish.encode('utf8') + b'       ')
         pass
 
     def test_utf8_valid(self):
         '''Test that a utf8 byte sequence is validated'''
         warnings.simplefilter('ignore', DeprecationWarning)
-        tools.ok_(utf8.utf8_valid(self.utf8_japanese) == True)
-        tools.ok_(utf8.utf8_valid(self.utf8_spanish) == True)
+        self.assertTrue(utf8.utf8_valid(self.utf8_japanese) == True)
+        self.assertTrue(utf8.utf8_valid(self.utf8_spanish) == True)
         warnings.simplefilter('default', DeprecationWarning)
 
     def test_utf8_invalid(self):
         '''Test that we return False with non-utf8 chars'''
         warnings.simplefilter('ignore', DeprecationWarning)
-        tools.ok_(utf8.utf8_valid(b'\xff') == False)
-        tools.ok_(utf8.utf8_valid(self.latin1_spanish) == False)
+        self.assertTrue(utf8.utf8_valid(b'\xff') == False)
+        self.assertTrue(utf8.utf8_valid(self.latin1_spanish) == False)
         warnings.simplefilter('default', DeprecationWarning)
 
     def test_utf8_text_wrap(self):
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_mixed) == [self.utf8_mixed])
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_paragraph) == self.utf8_paragraph_out)
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_mixed_para) == self.utf8_mixed_para_out)
-        tools.ok_(utf8.utf8_text_wrap(self.utf8_mixed_para, width=57,
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_mixed) == [self.utf8_mixed])
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_paragraph) == self.utf8_paragraph_out)
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_mixed_para) == self.utf8_mixed_para_out)
+        self.assertTrue(utf8.utf8_text_wrap(self.utf8_mixed_para, width=57,
             initial_indent=b'    ', subsequent_indent=b'----') ==
             self.utf8_mixed_para_57_initial_subsequent_out)

--- a/kitchen3/tests/test_versioning.py
+++ b/kitchen3/tests/test_versioning.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-from nose import tools
+
+import unittest
 
 from kitchen.versioning import version_tuple_to_string
 
 # Note: Using nose's generator tests for this so we can't subclass
 # unittest.TestCase
-class TestVersionTuple(object):
+class TestVersionTuple(unittest.TestCase):
     ver_to_tuple = {'1': ((1,),),
             '1.0': ((1, 0),),
             '1.0.0': ((1, 0, 0),),
@@ -25,7 +26,7 @@ class TestVersionTuple(object):
             }
 
     def check_ver_tuple_to_str(self, v_tuple, v_str):
-        tools.eq_(version_tuple_to_string(v_tuple), v_str)
+        self.assertEqual(version_tuple_to_string(v_tuple), v_str)
 
     def test_version_tuple_to_string(self):
         '''Test that version_tuple_to_string outputs PEP-386 compliant strings


### PR DESCRIPTION
Get rid of deprecated nose, it will stop functioning in future python versions.

In case you agree with the patch, I can also remove nose string from doc and comments.