### PR TITLE
Py3 converters: Remove print statements from getwriter

### DIFF
--- a/kitchen3/kitchen/text/converters.py
+++ b/kitchen3/kitchen/text/converters.py
@@ -338,8 +338,6 @@ def getwriter(encoding):
             codecs.StreamWriter.__init__(self, stream, errors)
 
         def encode(self, msg, errors='replace'):
-            print(type(msg))
-            print(repr(msg))
             return (to_bytes(msg, encoding=self.encoding, errors=errors),
                     len(msg))
 


### PR DESCRIPTION
Two print statements made it into the Python 3 version of text.converters.getwriter, causing messages to appear on the console when using this method. This PR removes those statements.